### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/adjacency_list/adjacency_list.py
+++ b/examples/adjacency_list/adjacency_list.py
@@ -33,7 +33,7 @@ class TreeNode(Base):
         self.parent = parent
 
     def __repr__(self):
-        return "TreeNode(name=%r, id=%r, parent_id=%r)" % (
+        return "TreeNode(name={0!r}, id={1!r}, parent_id={2!r})".format(
                     self.name,
                     self.id,
                     self.parent_id

--- a/examples/association/basic_association.py
+++ b/examples/association/basic_association.py
@@ -44,7 +44,7 @@ class Item(Base):
         self.price = price
 
     def __repr__(self):
-        return 'Item(%r, %r)' % (
+        return 'Item({0!r}, {1!r})'.format(
                     self.description, self.price
                 )
 

--- a/examples/association/proxied_association.py
+++ b/examples/association/proxied_association.py
@@ -41,7 +41,7 @@ class Item(Base):
         self.price = price
 
     def __repr__(self):
-        return 'Item(%r, %r)' % (
+        return 'Item({0!r}, {1!r})'.format(
                     self.description, self.price
                 )
 

--- a/examples/custom_attributes/listen_for_events.py
+++ b/examples/custom_attributes/listen_for_events.py
@@ -30,10 +30,10 @@ if __name__ == '__main__':
     class Base(object):
 
         def receive_change_event(self, verb, key, value, oldvalue):
-            s = "Value '%s' %s on attribute '%s', " % (value, verb, key)
+            s = "Value '{0!s}' {1!s} on attribute '{2!s}', ".format(value, verb, key)
             if oldvalue:
-                s += "which replaced the value '%s', " % oldvalue
-            s += "on object %s" % self
+                s += "which replaced the value '{0!s}', ".format(oldvalue)
+            s += "on object {0!s}".format(self)
             print(s)
 
     Base = declarative_base(cls=Base)
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         related = relationship("Related", backref="mapped")
 
         def __str__(self):
-            return "MyMappedClass(data=%r)" % self.data
+            return "MyMappedClass(data={0!r})".format(self.data)
 
     class Related(Base):
         __tablename__ = "related"
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         data = Column(String(50))
 
         def __str__(self):
-            return "Related(data=%r)" % self.data
+            return "Related(data={0!r})".format(self.data)
 
     # classes are instrumented.  Demonstrate the events !
 

--- a/examples/dogpile_caching/advanced.py
+++ b/examples/dogpile_caching/advanced.py
@@ -27,7 +27,7 @@ def load_name_range(start, end, invalidate=False):
     of data within the cache.
     """
     q = Session.query(Person).\
-            filter(Person.name.between("person %.2d" % start, "person %.2d" % end)).\
+            filter(Person.name.between("person {0:.2d}".format(start), "person {0:.2d}".format(end))).\
             options(cache_address_bits).\
             options(FromCache("default", "name_range"))
 

--- a/examples/dogpile_caching/environment.py
+++ b/examples/dogpile_caching/environment.py
@@ -43,7 +43,7 @@ if not os.path.exists(root):
     os.makedirs(root)
 
 dbfile = os.path.join(root, "dogpile_demo.db")
-engine = create_engine('sqlite:///%s' % dbfile, echo=True)
+engine = create_engine('sqlite:///{0!s}'.format(dbfile), echo=True)
 Session.configure(bind=engine)
 
 

--- a/examples/dogpile_caching/fixture_data.py
+++ b/examples/dogpile_caching/fixture_data.py
@@ -37,9 +37,9 @@ def install():
 
     for i in range(1, 51):
         person = Person(
-                    "person %.2d" % i,
+                    "person {0:.2d}".format(i),
                     Address(
-                        street="street %.2d" % i,
+                        street="street {0:.2d}".format(i),
                         postal_code=all_post_codes[
                                 random.randint(0, len(all_post_codes) - 1)]
                     )

--- a/examples/dogpile_caching/model.py
+++ b/examples/dogpile_caching/model.py
@@ -89,7 +89,7 @@ class Person(Base):
         return self.name
 
     def __repr__(self):
-        return "Person(name=%r)" % self.name
+        return "Person(name={0!r})".format(self.name)
 
     def format_full(self):
         return "\t".join([str(x) for x in [self] + list(self.addresses)])

--- a/examples/dynamic_dict/dynamic_dict.py
+++ b/examples/dynamic_dict/dynamic_dict.py
@@ -53,7 +53,7 @@ class Child(Base):
     parent_id = Column(Integer, ForeignKey('parent.id'))
 
     def __repr__(self):
-        return "Child(key=%r)" % self.key
+        return "Child(key={0!r})".format(self.key)
 
 Base.metadata.create_all()
 

--- a/examples/elementtree/adjacency_list.py
+++ b/examples/elementtree/adjacency_list.py
@@ -201,6 +201,6 @@ for path, compareto in (
         ('/somefile/header/field2', 'there'),
         ('/somefile/header/field2[@attr=foo]', 'there')
     ):
-    print("\nDocuments containing '%s=%s':" % (path, compareto), line)
+    print("\nDocuments containing '{0!s}={1!s}':".format(path, compareto), line)
     print([d.filename for d in find_document(path, compareto)])
 

--- a/examples/elementtree/optimized_al.py
+++ b/examples/elementtree/optimized_al.py
@@ -210,6 +210,6 @@ for path, compareto in (
         ('/somefile/header/field2', 'there'),
         ('/somefile/header/field2[@attr=foo]', 'there')
     ):
-    print("\nDocuments containing '%s=%s':" % (path, compareto), line)
+    print("\nDocuments containing '{0!s}={1!s}':".format(path, compareto), line)
     print([d.filename for d in find_document(path, compareto)])
 

--- a/examples/generic_associations/discriminator_on_association.py
+++ b/examples/generic_associations/discriminator_on_association.py
@@ -62,8 +62,7 @@ class Address(Base):
     parent = association_proxy("association", "parent")
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -81,7 +80,7 @@ class HasAddresses(object):
         discriminator = name.lower()
 
         assoc_cls = type(
-                        "%sAddressAssociation" % name,
+                        "{0!s}AddressAssociation".format(name),
                         (AddressAssociation, ),
                         dict(
                             __tablename__=None,

--- a/examples/generic_associations/generic_fk.py
+++ b/examples/generic_associations/generic_fk.py
@@ -65,11 +65,10 @@ class Address(Base):
         the appropriate relationship.
 
         """
-        return getattr(self, "parent_%s" % self.discriminator)
+        return getattr(self, "parent_{0!s}".format(self.discriminator))
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -88,7 +87,7 @@ def setup_listener(mapper, class_):
                                         Address.discriminator == discriminator
                                     ),
                         backref=backref(
-                                "parent_%s" % discriminator,
+                                "parent_{0!s}".format(discriminator),
                                 primaryjoin=remote(class_.id) == foreign(Address.parent_id)
                                 )
                         )

--- a/examples/generic_associations/table_per_association.py
+++ b/examples/generic_associations/table_per_association.py
@@ -41,8 +41,7 @@ class Address(Base):
     zip = Column(String)
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -53,12 +52,12 @@ class HasAddresses(object):
     @declared_attr
     def addresses(cls):
         address_association = Table(
-            "%s_addresses" % cls.__tablename__,
+            "{0!s}_addresses".format(cls.__tablename__),
             cls.metadata,
             Column("address_id", ForeignKey("address.id"),
                                 primary_key=True),
-            Column("%s_id" % cls.__tablename__,
-                                ForeignKey("%s.id" % cls.__tablename__),
+            Column("{0!s}_id".format(cls.__tablename__),
+                                ForeignKey("{0!s}.id".format(cls.__tablename__)),
                                 primary_key=True),
         )
         return relationship(Address, secondary=address_association)

--- a/examples/generic_associations/table_per_related.py
+++ b/examples/generic_associations/table_per_related.py
@@ -47,8 +47,7 @@ class Address(object):
     zip = Column(String)
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -59,13 +58,13 @@ class HasAddresses(object):
     @declared_attr
     def addresses(cls):
         cls.Address = type(
-            "%sAddress" % cls.__name__,
+            "{0!s}Address".format(cls.__name__),
             (Address, Base,),
             dict(
-                __tablename__="%s_address" %
-                            cls.__tablename__,
+                __tablename__="{0!s}_address".format(
+                            cls.__tablename__),
                 parent_id=Column(Integer,
-                            ForeignKey("%s.id" % cls.__tablename__)),
+                            ForeignKey("{0!s}.id".format(cls.__tablename__))),
                 parent=relationship(cls)
             )
         )

--- a/examples/inheritance/joined.py
+++ b/examples/inheritance/joined.py
@@ -17,7 +17,7 @@ class Company(Base):
                     cascade='all, delete-orphan')
 
     def __repr__(self):
-        return "Company %s" % self.name
+        return "Company {0!s}".format(self.name)
 
 class Person(Base):
     __tablename__ = 'person'
@@ -31,7 +31,7 @@ class Person(Base):
         'polymorphic_on':type
     }
     def __repr__(self):
-        return "Ordinary person %s" % self.name
+        return "Ordinary person {0!s}".format(self.name)
 
 class Engineer(Person):
     __tablename__ = 'engineer'
@@ -59,8 +59,7 @@ class Manager(Person):
         'polymorphic_identity':'manager',
     }
     def __repr__(self):
-        return "Manager %s, status %s, manager_name %s" % \
-                    (self.name, self.status, self.manager_name)
+        return "Manager {0!s}, status {1!s}, manager_name {2!s}".format(self.name, self.status, self.manager_name)
 
 
 engine = create_engine('sqlite://', echo=True)

--- a/examples/inheritance/single.py
+++ b/examples/inheritance/single.py
@@ -28,7 +28,7 @@ class Person(object):
         for key, value in kwargs.items():
             setattr(self, key, value)
     def __repr__(self):
-        return "Ordinary person %s" % self.name
+        return "Ordinary person {0!s}".format(self.name)
 class Engineer(Person):
     def __repr__(self):
         return "Engineer %s, status %s, engineer_name %s, "\
@@ -37,14 +37,13 @@ class Engineer(Person):
                         self.engineer_name, self.primary_language)
 class Manager(Person):
     def __repr__(self):
-        return "Manager %s, status %s, manager_name %s" % \
-                    (self.name, self.status, self.manager_name)
+        return "Manager {0!s}, status {1!s}, manager_name {2!s}".format(self.name, self.status, self.manager_name)
 class Company(object):
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
     def __repr__(self):
-        return "Company %s" % self.name
+        return "Company {0!s}".format(self.name)
 
 person_mapper = mapper(Person, employees_table,
                        polymorphic_on=employees_table.c.type,

--- a/examples/join_conditions/threeway.py
+++ b/examples/join_conditions/threeway.py
@@ -46,7 +46,7 @@ class First(Base):
     partition_key = Column(String)
 
     def __repr__(self):
-        return ("First(%s, %s)" % (self.first_id, self.partition_key))
+        return ("First({0!s}, {1!s})".format(self.first_id, self.partition_key))
 
 class Second(Base):
     __tablename__ = 'second'
@@ -61,7 +61,7 @@ class Partitioned(Base):
     partition_key = Column(String, primary_key=True)
 
     def __repr__(self):
-        return ("Partitioned(%s, %s)" % (self.other_id, self.partition_key))
+        return ("Partitioned({0!s}, {1!s})".format(self.other_id, self.partition_key))
 
 
 j = join(Partitioned, Second, Partitioned.other_id == Second.other_id)

--- a/examples/nested_sets/nested_sets.py
+++ b/examples/nested_sets/nested_sets.py
@@ -27,7 +27,7 @@ class Employee(Base):
     right = Column("rgt", Integer, nullable=False)
 
     def __repr__(self):
-        return "Employee(%s, %d, %d)" % (self.emp, self.left, self.right)
+        return "Employee({0!s}, {1:d}, {2:d})".format(self.emp, self.left, self.right)
 
 @event.listens_for(Employee, "before_insert")
 def before_insert(mapper, connection, instance):

--- a/examples/performance/__init__.py
+++ b/examples/performance/__init__.py
@@ -262,7 +262,7 @@ class Profiler(object):
     @classmethod
     def setup(cls, fn):
         if cls._setup is not None:
-            raise ValueError("setup function already set to %s" % cls._setup)
+            raise ValueError("setup function already set to {0!s}".format(cls._setup))
         cls._setup = staticmethod(fn)
         return fn
 
@@ -270,7 +270,7 @@ class Profiler(object):
     def setup_once(cls, fn):
         if cls._setup_once is not None:
             raise ValueError(
-                "setup_once function already set to %s" % cls._setup_once)
+                "setup_once function already set to {0!s}".format(cls._setup_once))
         cls._setup_once = staticmethod(fn)
         return fn
 
@@ -278,14 +278,14 @@ class Profiler(object):
         if self.test:
             tests = [fn for fn in self.tests if fn.__name__ == self.test]
             if not tests:
-                raise ValueError("No such test: %s" % self.test)
+                raise ValueError("No such test: {0!s}".format(self.test))
         else:
             tests = self.tests
 
         if self._setup_once:
             print("Running setup once...")
             self._setup_once(self.dburl, self.echo, self.num)
-        print("Tests to run: %s" % ", ".join([t.__name__ for t in tests]))
+        print("Tests to run: {0!s}".format(", ".join([t.__name__ for t in tests])))
         for test in tests:
             self._run_test(test)
             self.stats[-1].report()
@@ -397,12 +397,12 @@ class TestResult(object):
             self.report_stats()
 
     def _summary(self):
-        summary = "%s : %s (%d iterations)" % (
+        summary = "{0!s} : {1!s} ({2:d} iterations)".format(
             self.test.__name__, self.test.__doc__, self.profile.num)
         if self.total_time:
-            summary += "; total time %f sec" % self.total_time
+            summary += "; total time {0:f} sec".format(self.total_time)
         if self.stats:
-            summary += "; total fn calls %d" % self.stats.total_calls
+            summary += "; total fn calls {0:d}".format(self.stats.total_calls)
         return summary
 
     def report_stats(self):
@@ -418,10 +418,10 @@ class TestResult(object):
             self.stats.print_callers()
 
     def _runsnake(self):
-        filename = "%s.profile" % self.test.__name__
+        filename = "{0!s}.profile".format(self.test.__name__)
         try:
             self.stats.dump_stats(filename)
-            os.system("runsnake %s" % filename)
+            os.system("runsnake {0!s}".format(filename))
         finally:
             os.remove(filename)
 

--- a/examples/performance/bulk_inserts.py
+++ b/examples/performance/bulk_inserts.py
@@ -38,8 +38,8 @@ def test_flush_no_pk(n):
     for chunk in range(0, n, 1000):
         session.add_all([
             Customer(
-                name='customer name %d' % i,
-                description='customer description %d' % i)
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i))
             for i in range(chunk, chunk + 1000)
         ])
         session.flush()
@@ -52,8 +52,8 @@ def test_bulk_save_return_pks(n):
     session = Session(bind=engine)
     session.bulk_save_objects([
         Customer(
-            name='customer name %d' % i,
-            description='customer description %d' % i
+            name='customer name {0:d}'.format(i),
+            description='customer description {0:d}'.format(i)
         )
         for i in range(n)
     ], return_defaults=True)
@@ -68,8 +68,8 @@ def test_flush_pk_given(n):
         session.add_all([
             Customer(
                 id=i + 1,
-                name='customer name %d' % i,
-                description='customer description %d' % i)
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i))
             for i in range(chunk, chunk + 1000)
         ])
         session.flush()
@@ -82,8 +82,8 @@ def test_bulk_save(n):
     session = Session(bind=engine)
     session.bulk_save_objects([
         Customer(
-            name='customer name %d' % i,
-            description='customer description %d' % i
+            name='customer name {0:d}'.format(i),
+            description='customer description {0:d}'.format(i)
         )
         for i in range(n)
     ])
@@ -96,8 +96,8 @@ def test_bulk_insert_mappings(n):
     session = Session(bind=engine)
     session.bulk_insert_mappings(Customer, [
         dict(
-            name='customer name %d' % i,
-            description='customer description %d' % i
+            name='customer name {0:d}'.format(i),
+            description='customer description {0:d}'.format(i)
         )
         for i in range(n)
     ])
@@ -112,8 +112,8 @@ def test_core_insert(n):
         Customer.__table__.insert(),
         [
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )
             for i in range(n)
         ])
@@ -132,13 +132,13 @@ def test_dbapi_raw(n):
 
     if compiled.positional:
         args = (
-            ('customer name %d' % i, 'customer description %d' % i)
+            ('customer name {0:d}'.format(i), 'customer description {0:d}'.format(i))
             for i in range(n))
     else:
         args = (
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )
             for i in range(n)
         )

--- a/examples/performance/bulk_updates.py
+++ b/examples/performance/bulk_updates.py
@@ -34,8 +34,8 @@ def setup_database(dburl, echo, num):
     for chunk in range(0, num, 10000):
         s.bulk_insert_mappings(Customer, [
             {
-                'name': 'customer name %d' % i,
-                'description': 'customer description %d' % i
+                'name': 'customer name {0:d}'.format(i),
+                'description': 'customer description {0:d}'.format(i)
             } for i in range(chunk, chunk + 10000)
         ])
     s.commit()

--- a/examples/performance/large_resultsets.py
+++ b/examples/performance/large_resultsets.py
@@ -46,8 +46,8 @@ def setup_database(dburl, echo, num):
             Customer.__table__.insert(),
             params=[
                 {
-                    'name': 'customer name %d' % i,
-                    'description': 'customer description %d' % i
+                    'name': 'customer name {0:d}'.format(i),
+                    'description': 'customer description {0:d}'.format(i)
                 } for i in range(chunk, chunk + 10000)])
     s.commit()
 

--- a/examples/performance/short_selects.py
+++ b/examples/performance/short_selects.py
@@ -41,7 +41,7 @@ def setup_database(dburl, echo, num):
     sess = Session(engine)
     sess.add_all([
         Customer(
-            id=i, name='c%d' % i, description="c%d" % i,
+            id=i, name='c{0:d}'.format(i), description="c{0:d}".format(i),
             q=i * 10,
             p=i * 20,
             x=i * 30,

--- a/examples/performance/single_inserts.py
+++ b/examples/performance/single_inserts.py
@@ -42,8 +42,8 @@ def test_orm_commit(n):
         session = Session(bind=engine)
         session.add(
             Customer(
-                name='customer name %d' % i,
-                description='customer description %d' % i)
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i))
         )
         session.commit()
 
@@ -56,8 +56,8 @@ def test_bulk_save(n):
         session = Session(bind=engine)
         session.bulk_save_objects([
             Customer(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )])
         session.commit()
 
@@ -70,8 +70,8 @@ def test_bulk_insert_dictionaries(n):
         session = Session(bind=engine)
         session.bulk_insert_mappings(Customer, [
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )])
         session.commit()
 
@@ -85,8 +85,8 @@ def test_core(n):
             conn.execute(
                 Customer.__table__.insert(),
                 dict(
-                    name='customer name %d' % i,
-                    description='customer description %d' % i
+                    name='customer name {0:d}'.format(i),
+                    description='customer description {0:d}'.format(i)
                 )
             )
 
@@ -102,8 +102,8 @@ def test_core_query_caching(n):
             conn.execution_options(compiled_cache=cache).execute(
                 ins,
                 dict(
-                    name='customer name %d' % i,
-                    description='customer description %d' % i
+                    name='customer name {0:d}'.format(i),
+                    description='customer description {0:d}'.format(i)
                 )
             )
 
@@ -130,13 +130,13 @@ def _test_dbapi_raw(n, connect):
 
     if compiled.positional:
         args = (
-            ('customer name %d' % i, 'customer description %d' % i)
+            ('customer name {0:d}'.format(i), 'customer description {0:d}'.format(i))
             for i in range(n))
     else:
         args = (
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )
             for i in range(n)
         )

--- a/examples/postgis/postgis.py
+++ b/examples/postgis/postgis.py
@@ -12,7 +12,7 @@ class GisElement(object):
         return self.desc
 
     def __repr__(self):
-        return "<%s at 0x%x; %r>" % (self.__class__.__name__,
+        return "<{0!s} at 0x{1:x}; {2!r}>".format(self.__class__.__name__,
                                     id(self), self.desc)
 
 class BinaryGisElement(GisElement, expression.Function):

--- a/examples/versioned_history/history_meta.py
+++ b/examples/versioned_history/history_meta.py
@@ -128,7 +128,7 @@ def _history_mapper(local_mapper):
 
     else:
         bases = local_mapper.base_mapper.class_.__bases__
-    versioned_cls = type.__new__(type, "%sHistory" % cls.__name__, bases, {})
+    versioned_cls = type.__new__(type, "{0!s}History".format(cls.__name__), bases, {})
 
     m = mapper(
         versioned_cls,

--- a/examples/vertical/dictlike-polymorphic.py
+++ b/examples/vertical/dictlike-polymorphic.py
@@ -76,7 +76,7 @@ class PolymorphicVerticalProperty(object):
             pairs = set(self.cls.type_map.values())
             whens = [
                 (
-                    literal_column("'%s'" % discriminator),
+                    literal_column("'{0!s}'".format(discriminator)),
                     cast(getattr(self.cls, attribute), String)
                 ) for attribute, discriminator in pairs
                 if attribute is not None
@@ -88,7 +88,7 @@ class PolymorphicVerticalProperty(object):
             return self._case() != cast(other, String)
 
     def __repr__(self):
-        return '<%s %r=%r>' % (self.__class__.__name__, self.key, self.value)
+        return '<{0!s} {1!r}={2!r}>'.format(self.__class__.__name__, self.key, self.value)
 
 @event.listens_for(PolymorphicVerticalProperty, "mapper_configured", propagate=True)
 def on_new_class(mapper, cls_):
@@ -153,7 +153,7 @@ if __name__ == '__main__':
             self.name = name
 
         def __repr__(self):
-            return "Animal(%r)" % self.name
+            return "Animal({0!r})".format(self.name)
 
         @classmethod
         def with_characteristic(self, key, value):

--- a/examples/vertical/dictlike.py
+++ b/examples/vertical/dictlike.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
             self.name = name
 
         def __repr__(self):
-            return "Animal(%r)" % self.name
+            return "Animal({0!r})".format(self.name)
 
         @classmethod
         def with_characteristic(self, key, value):

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -67,12 +67,12 @@ class PyODBCConnector(Connector):
             dsn_connection = 'dsn' in keys or \
                              ('host' in keys and 'database' not in keys)
             if dsn_connection:
-                connectors = ['dsn=%s' % (keys.pop('host', '') or
-                                          keys.pop('dsn', ''))]
+                connectors = ['dsn={0!s}'.format((keys.pop('host', '') or
+                                          keys.pop('dsn', '')))]
             else:
                 port = ''
                 if 'port' in keys and 'port' not in query:
-                    port = ',%d' % int(keys.pop('port'))
+                    port = ',{0:d}'.format(int(keys.pop('port')))
 
                 connectors = []
                 driver = keys.pop('driver', self.pyodbc_driver_name)
@@ -82,18 +82,18 @@ class PyODBCConnector(Connector):
                         "this is expected by PyODBC when using "
                         "DSN-less connections")
                 else:
-                    connectors.append("DRIVER={%s}" % driver)
+                    connectors.append("DRIVER={{{0!s}}}".format(driver))
 
                 connectors.extend(
                     [
-                        'Server=%s%s' % (keys.pop('host', ''), port),
-                        'Database=%s' % keys.pop('database', '')
+                        'Server={0!s}{1!s}'.format(keys.pop('host', ''), port),
+                        'Database={0!s}'.format(keys.pop('database', ''))
                     ])
 
             user = keys.pop("user", None)
             if user:
-                connectors.append("UID=%s" % user)
-                connectors.append("PWD=%s" % keys.pop('password', ''))
+                connectors.append("UID={0!s}".format(user))
+                connectors.append("PWD={0!s}".format(keys.pop('password', '')))
             else:
                 connectors.append("Trusted_Connection=Yes")
 
@@ -102,10 +102,10 @@ class PyODBCConnector(Connector):
             # client encoding.  This should obviously be set to 'No' if
             # you query a cp1253 encoded database from a latin1 client...
             if 'odbc_autotranslate' in keys:
-                connectors.append("AutoTranslate=%s" %
-                                  keys.pop("odbc_autotranslate"))
+                connectors.append("AutoTranslate={0!s}".format(
+                                  keys.pop("odbc_autotranslate")))
 
-            connectors.extend(['%s=%s' % (k, v) for k, v in keys.items()])
+            connectors.extend(['{0!s}={1!s}'.format(k, v) for k, v in keys.items()])
         return [[";".join(connectors)], connect_args]
 
     def is_disconnect(self, e, connection, cursor):

--- a/lib/sqlalchemy/connectors/zxJDBC.py
+++ b/lib/sqlalchemy/connectors/zxJDBC.py
@@ -35,9 +35,9 @@ class ZxJDBCConnector(Connector):
 
     def _create_jdbc_url(self, url):
         """Create a JDBC url from a :class:`~sqlalchemy.engine.url.URL`"""
-        return 'jdbc:%s://%s%s/%s' % (self.jdbc_db_name, url.host,
+        return 'jdbc:{0!s}://{1!s}{2!s}/{3!s}'.format(self.jdbc_db_name, url.host,
                                       url.port is not None
-                                      and ':%s' % url.port or '',
+                                      and ':{0!s}'.format(url.port) or '',
                                       url.database)
 
     def create_connect_args(self, url):

--- a/lib/sqlalchemy/dialects/__init__.py
+++ b/lib/sqlalchemy/dialects/__init__.py
@@ -41,7 +41,7 @@ def _auto_fn(name):
         )
         dialect = translated
     try:
-        module = __import__('sqlalchemy.dialects.%s' % (dialect,)).dialects
+        module = __import__('sqlalchemy.dialects.{0!s}'.format(dialect)).dialects
     except ImportError:
         return None
 

--- a/lib/sqlalchemy/dialects/firebird/fdb.py
+++ b/lib/sqlalchemy/dialects/firebird/fdb.py
@@ -86,7 +86,7 @@ class FBDialect_fdb(FBDialect_kinterbasdb):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if opts.get('port'):
-            opts['host'] = "%s/%s" % (opts['host'], opts['port'])
+            opts['host'] = "{0!s}/{1!s}".format(opts['host'], opts['port'])
             del opts['port']
         opts.update(url.query)
 

--- a/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
+++ b/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
@@ -119,7 +119,7 @@ class FBDialect_kinterbasdb(FBDialect):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if opts.get('port'):
-            opts['host'] = "%s/%s" % (opts['host'], opts['port'])
+            opts['host'] = "{0!s}/{1!s}".format(opts['host'], opts['port'])
             del opts['port']
         opts.update(url.query)
 
@@ -164,7 +164,7 @@ class FBDialect_kinterbasdb(FBDialect):
             '\w+-V(\d+)\.(\d+)\.(\d+)\.(\d+)( \w+ (\d+)\.(\d+))?', version)
         if not m:
             raise AssertionError(
-                "Could not determine version from string '%s'" % version)
+                "Could not determine version from string '{0!s}'".format(version))
 
         if m.group(5) != None:
             return tuple([int(x) for x in m.group(6, 7, 4)] + ['firebird'])

--- a/lib/sqlalchemy/dialects/mssql/adodbapi.py
+++ b/lib/sqlalchemy/dialects/mssql/adodbapi.py
@@ -61,15 +61,14 @@ class MSDialect_adodbapi(MSDialect):
 
         connectors = ["Provider=SQLOLEDB"]
         if 'port' in keys:
-            connectors.append("Data Source=%s, %s" %
-                              (keys.get("host"), keys.get("port")))
+            connectors.append("Data Source={0!s}, {1!s}".format(keys.get("host"), keys.get("port")))
         else:
-            connectors.append("Data Source=%s" % keys.get("host"))
-        connectors.append("Initial Catalog=%s" % keys.get("database"))
+            connectors.append("Data Source={0!s}".format(keys.get("host")))
+        connectors.append("Initial Catalog={0!s}".format(keys.get("database")))
         user = keys.get("user")
         if user:
-            connectors.append("User Id=%s" % user)
-            connectors.append("Password=%s" % keys.get("password", ""))
+            connectors.append("User Id={0!s}".format(user))
+            connectors.append("Password={0!s}".format(keys.get("password", "")))
         else:
             connectors.append("Integrated Security=SSPI")
         return [[";".join(connectors)], {}]

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -645,7 +645,7 @@ class _MSDate(sqltypes.Date):
                 m = self._reg.match(value)
                 if not m:
                     raise ValueError(
-                        "could not parse %r as a date value" % (value,))
+                        "could not parse {0!r} as a date value".format(value))
                 return datetime.date(*[
                     int(x or 0)
                     for x in m.groups()
@@ -684,7 +684,7 @@ class TIME(sqltypes.TIME):
                 m = self._reg.match(value)
                 if not m:
                     raise ValueError(
-                        "could not parse %r as a time value" % (value,))
+                        "could not parse {0!r} as a time value".format(value))
                 return datetime.time(*[
                     int(x or 0)
                     for x in m.groups()])
@@ -855,7 +855,7 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
         """
 
         if getattr(type_, 'collation', None):
-            collation = 'COLLATE %s' % type_.collation
+            collation = 'COLLATE {0!s}'.format(type_.collation)
         else:
             collation = None
 
@@ -863,7 +863,7 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
             length = type_.length
 
         if length:
-            spec = spec + "(%s)" % length
+            spec = spec + "({0!s})".format(length)
 
         return ' '.join([c for c in (spec, collation)
                          if c is not None])
@@ -873,28 +873,28 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
         if precision is None:
             return "FLOAT"
         else:
-            return "FLOAT(%(precision)s)" % {'precision': precision}
+            return "FLOAT({precision!s})".format(**{'precision': precision})
 
     def visit_TINYINT(self, type_, **kw):
         return "TINYINT"
 
     def visit_DATETIMEOFFSET(self, type_, **kw):
         if type_.precision is not None:
-            return "DATETIMEOFFSET(%s)" % type_.precision
+            return "DATETIMEOFFSET({0!s})".format(type_.precision)
         else:
             return "DATETIMEOFFSET"
 
     def visit_TIME(self, type_, **kw):
         precision = getattr(type_, 'precision', None)
         if precision is not None:
-            return "TIME(%s)" % precision
+            return "TIME({0!s})".format(precision)
         else:
             return "TIME"
 
     def visit_DATETIME2(self, type_, **kw):
         precision = getattr(type_, 'precision', None)
         if precision is not None:
-            return "DATETIME2(%s)" % precision
+            return "DATETIME2({0!s})".format(precision)
         else:
             return "DATETIME2"
 
@@ -1031,8 +1031,8 @@ class MSExecutionContext(default.DefaultExecutionContext):
                 self.root_connection._cursor_execute(
                     self.cursor,
                     self._opt_encode(
-                        "SET IDENTITY_INSERT %s ON" %
-                        self.dialect.identifier_preparer.format_table(tbl)),
+                        "SET IDENTITY_INSERT {0!s} ON".format(
+                        self.dialect.identifier_preparer.format_table(tbl))),
                     (),
                     self)
 
@@ -1062,9 +1062,9 @@ class MSExecutionContext(default.DefaultExecutionContext):
             conn._cursor_execute(
                 self.cursor,
                 self._opt_encode(
-                    "SET IDENTITY_INSERT %s OFF" %
+                    "SET IDENTITY_INSERT {0!s} OFF".format(
                     self.dialect.identifier_preparer.format_table(
-                        self.compiled.statement.table)),
+                        self.compiled.statement.table))),
                 (),
                 self)
 
@@ -1076,9 +1076,9 @@ class MSExecutionContext(default.DefaultExecutionContext):
             try:
                 self.cursor.execute(
                     self._opt_encode(
-                        "SET IDENTITY_INSERT %s OFF" %
+                        "SET IDENTITY_INSERT {0!s} OFF".format(
                         self.dialect.identifier_preparer.format_table(
-                            self.compiled.statement.table)))
+                            self.compiled.statement.table))))
             except Exception:
                 pass
 
@@ -1122,14 +1122,13 @@ class MSSQLCompiler(compiler.SQLCompiler):
         return "GETDATE()"
 
     def visit_length_func(self, fn, **kw):
-        return "LEN%s" % self.function_argspec(fn, **kw)
+        return "LEN{0!s}".format(self.function_argspec(fn, **kw))
 
     def visit_char_length_func(self, fn, **kw):
-        return "LEN%s" % self.function_argspec(fn, **kw)
+        return "LEN{0!s}".format(self.function_argspec(fn, **kw))
 
     def visit_concat_op_binary(self, binary, operator, **kw):
-        return "%s + %s" % \
-               (self.process(binary.left, **kw),
+        return "{0!s} + {1!s}".format(self.process(binary.left, **kw),
                 self.process(binary.right, **kw))
 
     def visit_true(self, expr, **kw):
@@ -1139,7 +1138,7 @@ class MSSQLCompiler(compiler.SQLCompiler):
         return '0'
 
     def visit_match_op_binary(self, binary, operator, **kw):
-        return "CONTAINS (%s, %s)" % (
+        return "CONTAINS ({0!s}, {1!s})".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw))
 
@@ -1154,7 +1153,7 @@ class MSSQLCompiler(compiler.SQLCompiler):
             # ODBC drivers and possibly others
             # don't support bind params in the SELECT clause on SQL Server.
             # so have to use literal here.
-            s += "TOP %d " % select._limit
+            s += "TOP {0:d} ".format(select._limit)
 
         if s:
             return s
@@ -1274,16 +1273,14 @@ class MSSQLCompiler(compiler.SQLCompiler):
 
     def visit_extract(self, extract, **kw):
         field = self.extract_map.get(extract.field, extract.field)
-        return 'DATEPART(%s, %s)' % \
-               (field, self.process(extract.expr, **kw))
+        return 'DATEPART({0!s}, {1!s})'.format(field, self.process(extract.expr, **kw))
 
     def visit_savepoint(self, savepoint_stmt):
-        return "SAVE TRANSACTION %s" % \
-               self.preparer.format_savepoint(savepoint_stmt)
+        return "SAVE TRANSACTION {0!s}".format( \
+               self.preparer.format_savepoint(savepoint_stmt))
 
     def visit_rollback_to_savepoint(self, savepoint_stmt):
-        return ("ROLLBACK TRANSACTION %s"
-                % self.preparer.format_savepoint(savepoint_stmt))
+        return ("ROLLBACK TRANSACTION {0!s}".format(self.preparer.format_savepoint(savepoint_stmt)))
 
     def visit_binary(self, binary, **kwargs):
         """Move bind parameters to the right-hand side of an operator, where
@@ -1376,14 +1373,14 @@ class MSSQLStrictCompiler(MSSQLCompiler):
 
     def visit_in_op_binary(self, binary, operator, **kw):
         kw['literal_binds'] = True
-        return "%s IN %s" % (
+        return "{0!s} IN {1!s}".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
 
     def visit_notin_op_binary(self, binary, operator, **kw):
         kw['literal_binds'] = True
-        return "%s NOT IN %s" % (
+        return "{0!s} NOT IN {1!s}".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
@@ -1436,7 +1433,7 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 start = column.default.start or 1
 
-            colspec += " IDENTITY(%s,%s)" % (start,
+            colspec += " IDENTITY({0!s},{1!s})".format(start,
                                              column.default.increment or 1)
         elif column is column.table._autoincrement_column:
             colspec += " IDENTITY(1,1)"
@@ -1463,8 +1460,7 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 text += "NONCLUSTERED "
 
-        text += "INDEX %s ON %s (%s)" \
-                % (
+        text += "INDEX {0!s} ON {1!s} ({2!s})".format(
                     self._prepared_index_name(index,
                                               include_schema=include_schema),
                     preparer.format_table(index.table),
@@ -1483,14 +1479,13 @@ class MSDDLCompiler(compiler.DDLCompiler):
                           index.dialect_options['mssql']['include']
                           ]
 
-            text += " INCLUDE (%s)" \
-                    % ', '.join([preparer.quote(c.name)
-                                 for c in inclusions])
+            text += " INCLUDE ({0!s})".format(', '.join([preparer.quote(c.name)
+                                 for c in inclusions]))
 
         return text
 
     def visit_drop_index(self, drop):
-        return "\nDROP INDEX %s ON %s" % (
+        return "\nDROP INDEX {0!s} ON {1!s}".format(
             self._prepared_index_name(drop.element, include_schema=False),
             self.preparer.format_table(drop.element.table)
         )
@@ -1500,8 +1495,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             return ''
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                    self.preparer.format_constraint(constraint)
+            text += "CONSTRAINT {0!s} ".format( \
+                    self.preparer.format_constraint(constraint))
         text += "PRIMARY KEY "
 
         clustered = constraint.dialect_options['mssql']['clustered']
@@ -1511,8 +1506,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 text += "NONCLUSTERED "
 
-        text += "(%s)" % ', '.join(self.preparer.quote(c.name)
-                                   for c in constraint)
+        text += "({0!s})".format(', '.join(self.preparer.quote(c.name)
+                                   for c in constraint))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -1521,8 +1516,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             return ''
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                    self.preparer.format_constraint(constraint)
+            text += "CONSTRAINT {0!s} ".format( \
+                    self.preparer.format_constraint(constraint))
         text += "UNIQUE "
 
         clustered = constraint.dialect_options['mssql']['clustered']
@@ -1532,8 +1527,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 text += "NONCLUSTERED "
 
-        text += "(%s)" % ', '.join(self.preparer.quote(c.name)
-                                   for c in constraint)
+        text += "({0!s})".format(', '.join(self.preparer.quote(c.name)
+                                   for c in constraint))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -1575,12 +1570,12 @@ def _db_plus_owner(fn):
 def _switch_db(dbname, connection, fn, *arg, **kw):
     if dbname:
         current_db = connection.scalar("select db_name()")
-        connection.execute("use %s" % dbname)
+        connection.execute("use {0!s}".format(dbname))
     try:
         return fn(*arg, **kw)
     finally:
         if dbname:
-            connection.execute("use %s" % current_db)
+            connection.execute("use {0!s}".format(current_db))
 
 
 def _owner_plus_db(dialect, schema):
@@ -1681,7 +1676,7 @@ class MSDialect(default.DefaultDialect):
             )
         cursor = connection.cursor()
         cursor.execute(
-            "SET TRANSACTION ISOLATION LEVEL %s" % level)
+            "SET TRANSACTION ISOLATION LEVEL {0!s}".format(level))
         cursor.close()
 
     def get_isolation_level(self, connection):
@@ -1932,8 +1927,7 @@ class MSDialect(default.DefaultDialect):
 
             if coltype is None:
                 util.warn(
-                    "Did not recognize type '%s' of column '%s'" %
-                    (type, name))
+                    "Did not recognize type '{0!s}' of column '{1!s}'".format(type, name))
                 coltype = sqltypes.NULLTYPE
             else:
                 if issubclass(coltype, sqltypes.Numeric) and \
@@ -1968,15 +1962,14 @@ class MSDialect(default.DefaultDialect):
                 ic = col_name
                 colmap[col_name]['autoincrement'] = True
                 colmap[col_name]['sequence'] = dict(
-                    name='%s_identity' % col_name)
+                    name='{0!s}_identity'.format(col_name))
                 break
         cursor.close()
 
         if ic is not None and self.server_version_info >= MS_2005_VERSION:
-            table_fullname = "%s.%s" % (owner, tablename)
+            table_fullname = "{0!s}.{1!s}".format(owner, tablename)
             cursor = connection.execute(
-                "select ident_seed('%s'), ident_incr('%s')"
-                % (table_fullname, table_fullname)
+                "select ident_seed('{0!s}'), ident_incr('{1!s}')".format(table_fullname, table_fullname)
             )
 
             row = cursor.first()

--- a/lib/sqlalchemy/dialects/mssql/mxodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/mxodbc.py
@@ -60,7 +60,7 @@ class _MSDate_mxodbc(_MSDate):
     def bind_processor(self, dialect):
         def process(value):
             if value is not None:
-                return "%s-%s-%s" % (value.year, value.month, value.day)
+                return "{0!s}-{1!s}-{2!s}".format(value.year, value.month, value.day)
             else:
                 return None
 
@@ -71,7 +71,7 @@ class _MSTime_mxodbc(_MSTime):
     def bind_processor(self, dialect):
         def process(value):
             if value is not None:
-                return "%s:%s:%s" % (value.hour, value.minute, value.second)
+                return "{0!s}:{1!s}:{2!s}".format(value.hour, value.minute, value.second)
             else:
                 return None
 

--- a/lib/sqlalchemy/dialects/mssql/pymssql.py
+++ b/lib/sqlalchemy/dialects/mssql/pymssql.py
@@ -75,7 +75,7 @@ class MSDialect_pymssql(MSDialect):
         opts.update(url.query)
         port = opts.pop('port', None)
         if port and 'host' in opts:
-            opts['host'] = "%s:%s" % (opts['host'], port)
+            opts['host'] = "{0!s}:{1!s}".format(opts['host'], port)
         return [[], opts]
 
     def is_disconnect(self, e, connection, cursor):

--- a/lib/sqlalchemy/dialects/mssql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/pyodbc.py
@@ -145,7 +145,7 @@ class _ms_numeric_pyodbc(object):
     # as of 2.1.8 this logic is integrated.
 
     def _small_dec_to_string(self, value):
-        return "%s0.%s%s" % (
+        return "{0!s}0.{1!s}{2!s}".format(
             (value < 0 and '-' or ''),
             '0' * (abs(value.adjusted()) - 1),
             "".join([str(nint) for nint in value.as_tuple()[1]]))
@@ -153,20 +153,20 @@ class _ms_numeric_pyodbc(object):
     def _large_dec_to_string(self, value):
         _int = value.as_tuple()[1]
         if 'E' in str(value):
-            result = "%s%s%s" % (
+            result = "{0!s}{1!s}{2!s}".format(
                 (value < 0 and '-' or ''),
                 "".join([str(s) for s in _int]),
                 "0" * (value.adjusted() - (len(_int) - 1)))
         else:
             if (len(_int) - 1) > value.adjusted():
-                result = "%s%s.%s" % (
+                result = "{0!s}{1!s}.{2!s}".format(
                     (value < 0 and '-' or ''),
                     "".join(
                         [str(s) for s in _int][0:value.adjusted() + 1]),
                     "".join(
                         [str(s) for s in _int][value.adjusted() + 1:]))
             else:
-                result = "%s%s" % (
+                result = "{0!s}{1!s}".format(
                     (value < 0 and '-' or ''),
                     "".join(
                         [str(s) for s in _int][0:value.adjusted() + 1]))

--- a/lib/sqlalchemy/dialects/mssql/zxjdbc.py
+++ b/lib/sqlalchemy/dialects/mssql/zxjdbc.py
@@ -50,7 +50,7 @@ class MSExecutionContext_zxjdbc(MSExecutionContext):
         if self._enable_identity_insert:
             table = self.dialect.identifier_preparer.format_table(
                 self.compiled.statement.table)
-            self.cursor.execute("SET IDENTITY_INSERT %s OFF" % table)
+            self.cursor.execute("SET IDENTITY_INSERT {0!s} OFF".format(table))
 
 
 class MSDialect_zxjdbc(ZxJDBCConnector, MSDialect):

--- a/lib/sqlalchemy/dialects/mysql/json.py
+++ b/lib/sqlalchemy/dialects/mysql/json.py
@@ -62,17 +62,17 @@ class _FormatTypeMixin(object):
 class JSONIndexType(_FormatTypeMixin, sqltypes.JSON.JSONIndexType):
     def _format_value(self, value):
         if isinstance(value, int):
-            value = "$[%s]" % value
+            value = "$[{0!s}]".format(value)
         else:
-            value = '$."%s"' % value
+            value = '$."{0!s}"'.format(value)
         return value
 
 
 class JSONPathType(_FormatTypeMixin, sqltypes.JSON.JSONPathType):
     def _format_value(self, value):
-        return "$%s" % (
+        return "${0!s}".format((
             "".join([
-                        "[%s]" % elem if isinstance(elem, int)
-                        else '."%s"' % elem for elem in value
+                        "[{0!s}]".format(elem) if isinstance(elem, int)
+                        else '."{0!s}"'.format(elem) for elem in value
                         ])
-        )
+        ))

--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -101,8 +101,7 @@ class MySQLDialect_mysqldb(MySQLDialect):
 
         has_utf8_bin = self.server_version_info > (5,) and \
                        connection.scalar(
-                           "show collation where %s = 'utf8' and %s = 'utf8_bin'"
-                           % (
+                           "show collation where {0!s} = 'utf8' and {1!s} = 'utf8_bin'".format(
                                self.identifier_preparer.quote("Charset"),
                                self.identifier_preparer.quote("Collation")
                            ))

--- a/lib/sqlalchemy/dialects/mysql/oursql.py
+++ b/lib/sqlalchemy/dialects/mysql/oursql.py
@@ -85,7 +85,7 @@ class MySQLDialect_oursql(MySQLDialect):
             charset = self._connection_charset
             arg = connection.connection._escape_string(
                 xid.encode(charset)).decode(charset)
-        arg = "'%s'" % arg
+        arg = "'{0!s}'".format(arg)
         connection.execution_options(
             _oursql_plain_query=True).execute(query % arg)
 

--- a/lib/sqlalchemy/dialects/mysql/reflection.py
+++ b/lib/sqlalchemy/dialects/mysql/reflection.py
@@ -53,7 +53,7 @@ class MySQLTableDefinitionParser(object):
             else:
                 type_, spec = self._parse_constraints(line)
                 if type_ is None:
-                    util.warn("Unknown schema content: %r" % line)
+                    util.warn("Unknown schema content: {0!r}".format(line))
                 elif type_ == 'key':
                     state.keys.append(spec)
                 elif type_ == 'constraint':
@@ -135,7 +135,7 @@ class MySQLTableDefinitionParser(object):
             options.pop(nope, None)
 
         for opt, val in options.items():
-            state.table_options['%s_%s' % (self.dialect.name, opt)] = val
+            state.table_options['{0!s}_{1!s}'.format(self.dialect.name, opt)] = val
 
     def _parse_column(self, line, state):
         """Extract column details.
@@ -156,18 +156,17 @@ class MySQLTableDefinitionParser(object):
                 spec = m.groupdict()
                 spec['full'] = False
         if not spec:
-            util.warn("Unknown column definition %r" % line)
+            util.warn("Unknown column definition {0!r}".format(line))
             return
         if not spec['full']:
-            util.warn("Incomplete reflection of column definition %r" % line)
+            util.warn("Incomplete reflection of column definition {0!r}".format(line))
 
         name, type_, args = spec['name'], spec['coltype'], spec['arg']
 
         try:
             col_type = self.dialect.ischema_names[type_]
         except KeyError:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (type_, name))
+            util.warn("Did not recognize type '{0!s}' of column '{1!s}'".format(type_, name))
             col_type = sqltypes.NullType
 
         # Column type positional arguments eg. varchar(32)
@@ -258,14 +257,14 @@ class MySQLTableDefinitionParser(object):
                     line.append(default)
                 else:
                     line.append('DEFAULT')
-                    line.append("'%s'" % default.replace("'", "''"))
+                    line.append("'{0!s}'".format(default.replace("'", "''")))
             if extra:
                 line.append(extra)
 
             buffer.append(' '.join(line))
 
-        return ''.join([('CREATE TABLE %s (\n' %
-                         self.preparer.quote_identifier(table_name)),
+        return ''.join([('CREATE TABLE {0!s} (\n'.format(
+                         self.preparer.quote_identifier(table_name))),
                         ',\n'.join(buffer),
                         '\n) '])
 

--- a/lib/sqlalchemy/dialects/oracle/base.py
+++ b/lib/sqlalchemy/dialects/oracle/base.py
@@ -475,13 +475,13 @@ class OracleTypeCompiler(compiler.GenericTypeCompiler):
             return self.visit_VARCHAR2(type_, **kw)
 
     def visit_INTERVAL(self, type_, **kw):
-        return "INTERVAL DAY%s TO SECOND%s" % (
+        return "INTERVAL DAY{0!s} TO SECOND{1!s}".format(
             type_.day_precision is not None and
-            "(%d)" % type_.day_precision or
+            "({0:d})".format(type_.day_precision) or
             "",
             type_.second_precision is not None and
-            "(%d)" % type_.second_precision or
-            "",
+            "({0:d})".format(type_.second_precision) or
+            ""
         )
 
     def visit_LONG(self, type_, **kw):
@@ -531,7 +531,7 @@ class OracleTypeCompiler(compiler.GenericTypeCompiler):
 
     def _visit_varchar(self, type_, n, num):
         if not type_.length:
-            return "%(n)sVARCHAR%(two)s" % {'two': num, 'n': n}
+            return "{n!s}VARCHAR{two!s}".format(**{'two': num, 'n': n})
         elif not n and self.dialect._supports_char_length:
             varchar = "VARCHAR%(two)s(%(length)s CHAR)"
             return varchar % {'length': type_.length, 'two': num}
@@ -559,7 +559,7 @@ class OracleTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_RAW(self, type_, **kw):
         if type_.length:
-            return "RAW(%(length)s)" % {'length': type_.length}
+            return "RAW({length!s})".format(**{'length': type_.length})
         else:
             return "RAW"
 
@@ -586,7 +586,7 @@ class OracleCompiler(compiler.SQLCompiler):
         super(OracleCompiler, self).__init__(*args, **kwargs)
 
     def visit_mod_binary(self, binary, operator, **kw):
-        return "mod(%s, %s)" % (self.process(binary.left, **kw),
+        return "mod({0!s}, {1!s})".format(self.process(binary.left, **kw),
                                 self.process(binary.right, **kw))
 
     def visit_now_func(self, fn, **kw):
@@ -596,7 +596,7 @@ class OracleCompiler(compiler.SQLCompiler):
         return "LENGTH" + self.function_argspec(fn, **kw)
 
     def visit_match_op_binary(self, binary, operator, **kw):
-        return "CONTAINS (%s, %s)" % (self.process(binary.left),
+        return "CONTAINS ({0!s}, {1!s})".format(self.process(binary.left),
                                       self.process(binary.right))
 
     def visit_true(self, expr, **kw):
@@ -610,7 +610,7 @@ class OracleCompiler(compiler.SQLCompiler):
 
     def get_select_hint_text(self, byfroms):
         return " ".join(
-            "/*+ %s */" % text for table, text in byfroms.items()
+            "/*+ {0!s} */".format(text) for table, text in byfroms.items()
         )
 
     def function_argspec(self, fn, **kw):
@@ -693,7 +693,7 @@ class OracleCompiler(compiler.SQLCompiler):
                 col_expr = column.type.column_expression(column)
             else:
                 col_expr = column
-            outparam = sql.outparam("ret_%d" % i, type_=column.type)
+            outparam = sql.outparam("ret_{0:d}".format(i), type_=column.type)
             self.binds[outparam.key] = outparam
             binds.append(
                 self.bindparam_string(self._truncate_bindparam(outparam)))
@@ -754,8 +754,8 @@ class OracleCompiler(compiler.SQLCompiler):
                         self.dialect.optimize_limits and \
                         select._simple_int_limit:
                     limitselect = limitselect.prefix_with(
-                        "/*+ FIRST_ROWS(%d) */" %
-                        select._limit)
+                        "/*+ FIRST_ROWS({0:d}) */".format(
+                        select._limit))
 
                 limitselect._oracle_visit = True
                 limitselect._is_wrapper = True
@@ -783,7 +783,7 @@ class OracleCompiler(compiler.SQLCompiler):
 
                         if offset_clause is not None:
                             max_row += select._offset
-                        max_row = sql.literal_column("%d" % max_row)
+                        max_row = sql.literal_column("{0:d}".format(max_row))
                     else:
                         max_row = limit_clause
                         if offset_clause is not None:
@@ -813,7 +813,7 @@ class OracleCompiler(compiler.SQLCompiler):
 
                     if not self.dialect.use_binds_for_limits:
                         offset_clause = sql.literal_column(
-                            "%d" % select._offset)
+                            "{0:d}".format(select._offset))
                     offsetselect.append_whereclause(
                         sql.literal_column("ora_rn") > offset_clause)
 
@@ -849,7 +849,7 @@ class OracleDDLCompiler(compiler.DDLCompiler):
     def define_constraint_cascades(self, constraint):
         text = ""
         if constraint.ondelete is not None:
-            text += " ON DELETE %s" % constraint.ondelete
+            text += " ON DELETE {0!s}".format(constraint.ondelete)
 
         # oracle has no ON UPDATE CASCADE -
         # its only available via triggers
@@ -872,7 +872,7 @@ class OracleDDLCompiler(compiler.DDLCompiler):
             text += "UNIQUE "
         if index.dialect_options['oracle']['bitmap']:
             text += "BITMAP "
-        text += "INDEX %s ON %s (%s)" % (
+        text += "INDEX {0!s} ON {1!s} ({2!s})".format(
             self._prepared_index_name(index, include_schema=True),
             preparer.format_table(index.table, use_schema=True),
             ', '.join(
@@ -885,9 +885,9 @@ class OracleDDLCompiler(compiler.DDLCompiler):
             if index.dialect_options['oracle']['compress'] is True:
                 text += " COMPRESS"
             else:
-                text += " COMPRESS %d" % (
+                text += " COMPRESS {0:d}".format((
                     index.dialect_options['oracle']['compress']
-                )
+                ))
         return text
 
     def post_create_table(self, table):
@@ -896,15 +896,15 @@ class OracleDDLCompiler(compiler.DDLCompiler):
 
         if opts['on_commit']:
             on_commit_options = opts['on_commit'].replace("_", " ").upper()
-            table_opts.append('\n ON COMMIT %s' % on_commit_options)
+            table_opts.append('\n ON COMMIT {0!s}'.format(on_commit_options))
 
         if opts['compress']:
             if opts['compress'] is True:
                 table_opts.append("\n COMPRESS")
             else:
-                table_opts.append("\n COMPRESS FOR %s" % (
+                table_opts.append("\n COMPRESS FOR {0!s}".format((
                     opts['compress']
-                ))
+                )))
 
         return ''.join(table_opts)
 
@@ -1301,8 +1301,7 @@ class OracleDialect(default.DefaultDialect):
                 try:
                     coltype = self.ischema_names[coltype]
                 except KeyError:
-                    util.warn("Did not recognize type '%s' of column '%s'" %
-                              (coltype, colname))
+                    util.warn("Did not recognize type '{0!s}' of column '{1!s}'".format(coltype, colname))
                     coltype = sqltypes.NULLTYPE
 
             cdict = {

--- a/lib/sqlalchemy/dialects/oracle/cx_oracle.py
+++ b/lib/sqlalchemy/dialects/oracle/cx_oracle.py
@@ -317,7 +317,7 @@ class _OracleNumeric(sqltypes.Numeric):
 
         if dialect.supports_native_decimal:
             if self.asdecimal:
-                fstring = "%%.%df" % self._effective_decimal_return_scale
+                fstring = "%.{0:d}f".format(self._effective_decimal_return_scale)
 
                 def to_decimal(value):
                     if value is None:
@@ -495,7 +495,7 @@ class OracleCompiler_cx_oracle(OracleCompiler):
         quote = getattr(name, 'quote', None)
         if quote is True or quote is not False and \
                 self.preparer._bindparam_requires_quotes(name):
-            quoted_name = '"%s"' % name
+            quoted_name = '"{0!s}"'.format(name)
             self._quoted_bind_names[name] = quoted_name
             return OracleCompiler.bindparam_string(self, quoted_name, **kw)
         else:
@@ -643,13 +643,13 @@ class ReturningResultProxy(_result.FullyBufferedResultProxy):
     def _cursor_description(self):
         returning = self.context.compiled.returning
         return [
-            ("ret_%d" % i, None)
+            ("ret_{0:d}".format(i), None)
             for i, col in enumerate(returning)
             ]
 
     def _buffer_rows(self):
         return collections.deque(
-            [tuple(self._returning_params["ret_%d" % i]
+            [tuple(self._returning_params["ret_{0:d}".format(i)]
                    for i, c in enumerate(self._returning_params))]
         )
 
@@ -983,7 +983,7 @@ class OracleDialect_cx_oracle(OracleDialect):
         do_commit_twophase().  its format is unspecified."""
 
         id = random.randint(0, 2 ** 128)
-        return (0x1234, "%032x" % id, "%032x" % 9)
+        return (0x1234, "{0:032x}".format(id), "{0:032x}".format(9))
 
     def do_executemany(self, cursor, statement, parameters, context=None):
         if isinstance(parameters, tuple):

--- a/lib/sqlalchemy/dialects/oracle/zxjdbc.py
+++ b/lib/sqlalchemy/dialects/oracle/zxjdbc.py
@@ -81,7 +81,7 @@ class OracleCompiler_zxjdbc(OracleCompiler):
             self.returning_parameters.append((i + 1, dbtype))
 
             bindparam = sql.bindparam(
-                "ret_%d" % i, value=ReturningParam(dbtype))
+                "ret_{0:d}".format(i), value=ReturningParam(dbtype))
             self.binds[bindparam.key] = bindparam
             binds.append(
                 self.bindparam_string(self._truncate_bindparam(bindparam)))
@@ -104,10 +104,10 @@ class OracleExecutionContext_zxjdbc(OracleExecutionContext):
                     rrs = self.statement.__statement__.getReturnResultSet()
                     next(rrs)
                 except SQLException as sqle:
-                    msg = '%s [SQLCode: %d]' % (
+                    msg = '{0!s} [SQLCode: {1:d}]'.format(
                         sqle.getMessage(), sqle.getErrorCode())
                     if sqle.getSQLState() is not None:
-                        msg += ' [SQLState: %s]' % sqle.getSQLState()
+                        msg += ' [SQLState: {0!s}]'.format(sqle.getSQLState())
                     raise zxJDBC.Error(msg)
                 else:
                     row = tuple(
@@ -173,7 +173,7 @@ class ReturningParam(object):
 
     def __repr__(self):
         kls = self.__class__
-        return '<%s.%s object at 0x%x type=%s>' % (
+        return '<{0!s}.{1!s} object at 0x{2:x} type={3!s}>'.format(
             kls.__module__, kls.__name__, id(self), self.type)
 
 
@@ -220,7 +220,7 @@ class OracleDialect_zxjdbc(ZxJDBCConnector, OracleDialect):
             connection.connection.driverversion >= '10.2'
 
     def _create_jdbc_url(self, url):
-        return 'jdbc:oracle:thin:@%s:%s:%s' % (
+        return 'jdbc:oracle:thin:@{0!s}:{1!s}:{2!s}'.format(
             url.host, url.port or 1521, url.database)
 
     def _get_server_version_info(self, connection):

--- a/lib/sqlalchemy/dialects/postgresql/base.py
+++ b/lib/sqlalchemy/dialects/postgresql/base.py
@@ -1265,12 +1265,12 @@ ischema_names = {
 
 class PGCompiler(compiler.SQLCompiler):
     def visit_array(self, element, **kw):
-        return "ARRAY[%s]" % self.visit_clauselist(element, **kw)
+        return "ARRAY[{0!s}]".format(self.visit_clauselist(element, **kw))
 
     def visit_slice(self, element, **kw):
-        return "%s:%s" % (
+        return "{0!s}:{1!s}".format(
             self.process(element.start, **kw),
-            self.process(element.stop, **kw),
+            self.process(element.stop, **kw)
         )
 
     def visit_json_getitem_op_binary(self, binary, operator, **kw):
@@ -1284,13 +1284,13 @@ class PGCompiler(compiler.SQLCompiler):
         )
 
     def visit_getitem_binary(self, binary, operator, **kw):
-        return "%s[%s]" % (
+        return "{0!s}[{1!s}]".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
 
     def visit_aggregate_order_by(self, element, **kw):
-        return "%s ORDER BY %s" % (
+        return "{0!s} ORDER BY {1!s}".format(
             self.process(element.target, **kw),
             self.process(element.order_by, **kw)
         )
@@ -1301,12 +1301,12 @@ class PGCompiler(compiler.SQLCompiler):
                 binary.modifiers['postgresql_regconfig'],
                 sqltypes.STRINGTYPE)
             if regconfig:
-                return "%s @@ to_tsquery(%s, %s)" % (
+                return "{0!s} @@ to_tsquery({1!s}, {2!s})".format(
                     self.process(binary.left, **kw),
                     regconfig,
                     self.process(binary.right, **kw)
                 )
-        return "%s @@ to_tsquery(%s)" % (
+        return "{0!s} @@ to_tsquery({1!s})".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
@@ -1314,8 +1314,7 @@ class PGCompiler(compiler.SQLCompiler):
     def visit_ilike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
 
-        return '%s ILIKE %s' % \
-               (self.process(binary.left, **kw),
+        return '{0!s} ILIKE {1!s}'.format(self.process(binary.left, **kw),
                 self.process(binary.right, **kw)) \
                + (
                    ' ESCAPE ' +
@@ -1325,8 +1324,7 @@ class PGCompiler(compiler.SQLCompiler):
 
     def visit_notilike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
-        return '%s NOT ILIKE %s' % \
-               (self.process(binary.left, **kw),
+        return '{0!s} NOT ILIKE {1!s}'.format(self.process(binary.left, **kw),
                 self.process(binary.right, **kw)) \
                + (
                    ' ESCAPE ' +
@@ -1342,7 +1340,7 @@ class PGCompiler(compiler.SQLCompiler):
         return value
 
     def visit_sequence(self, seq):
-        return "nextval('%s')" % self.preparer.format_sequence(seq)
+        return "nextval('{0!s}')".format(self.preparer.format_sequence(seq))
 
     def limit_clause(self, select, **kw):
         text = ""
@@ -1356,7 +1354,7 @@ class PGCompiler(compiler.SQLCompiler):
 
     def format_from_hint_text(self, sqltext, table, hint, iscrud):
         if hint.upper() != 'ONLY':
-            raise exc.CompileError("Unrecognized hint: %r" % hint)
+            raise exc.CompileError("Unrecognized hint: {0!r}".format(hint))
         return "ONLY " + sqltext
 
     def get_select_precolumns(self, select, **kw):
@@ -1415,29 +1413,29 @@ class PGCompiler(compiler.SQLCompiler):
         start = self.process(func.clauses.clauses[1], **kw)
         if len(func.clauses.clauses) > 2:
             length = self.process(func.clauses.clauses[2], **kw)
-            return "SUBSTRING(%s FROM %s FOR %s)" % (s, start, length)
+            return "SUBSTRING({0!s} FROM {1!s} FOR {2!s})".format(s, start, length)
         else:
-            return "SUBSTRING(%s FROM %s)" % (s, start)
+            return "SUBSTRING({0!s} FROM {1!s})".format(s, start)
 
     def _on_conflict_target(self, clause, **kw):
 
         if clause.constraint_target is not None:
-            target_text = 'ON CONSTRAINT %s' % clause.constraint_target
+            target_text = 'ON CONSTRAINT {0!s}'.format(clause.constraint_target)
         elif clause.inferred_target_elements is not None:
-            target_text = '(%s)' % ', '.join(
+            target_text = '({0!s})'.format(', '.join(
                 (self.preparer.quote(c)
                  if isinstance(c, util.string_types)
                  else
                  self.process(c, include_table=False, use_schema=False))
                 for c in clause.inferred_target_elements
-            )
+            ))
             if clause.inferred_target_whereclause is not None:
-                target_text += ' WHERE %s' % \
+                target_text += ' WHERE {0!s}'.format( \
                                self.process(
                                    clause.inferred_target_whereclause,
                                    include_table=False,
                                    use_schema=False
-                               )
+                               ))
         else:
             target_text = ''
 
@@ -1448,7 +1446,7 @@ class PGCompiler(compiler.SQLCompiler):
         target_text = self._on_conflict_target(on_conflict, **kw)
 
         if target_text:
-            return "ON CONFLICT %s DO NOTHING" % target_text
+            return "ON CONFLICT {0!s} DO NOTHING".format(target_text)
         else:
             return "ON CONFLICT DO NOTHING"
 
@@ -1469,17 +1467,17 @@ class PGCompiler(compiler.SQLCompiler):
                 v,
                 use_schema=False
             )
-            action_set_ops.append('%s = %s' % (key_text, value_text))
+            action_set_ops.append('{0!s} = {1!s}'.format(key_text, value_text))
         action_text = ', '.join(action_set_ops)
         if clause.update_whereclause is not None:
-            action_text += ' WHERE %s' % \
+            action_text += ' WHERE {0!s}'.format( \
                            self.process(
                                clause.update_whereclause,
                                include_table=False,
                                use_schema=False
-                           )
+                           ))
 
-        return 'ON CONFLICT %s DO UPDATE SET %s' % (target_text, action_text)
+        return 'ON CONFLICT {0!s} DO UPDATE SET {1!s}'.format(target_text, action_text)
 
 
 class PGDDLCompiler(compiler.DDLCompiler):
@@ -1521,7 +1519,7 @@ class PGDDLCompiler(compiler.DDLCompiler):
     def visit_create_enum_type(self, create):
         type_ = create.element
 
-        return "CREATE TYPE %s AS ENUM (%s)" % (
+        return "CREATE TYPE {0!s} AS ENUM ({1!s})".format(
             self.preparer.format_type(type_),
             ", ".join(
                 self.sql_compiler.process(sql.literal(e), literal_binds=True)
@@ -1531,9 +1529,9 @@ class PGDDLCompiler(compiler.DDLCompiler):
     def visit_drop_enum_type(self, drop):
         type_ = drop.element
 
-        return "DROP TYPE %s" % (
+        return "DROP TYPE {0!s}".format((
             self.preparer.format_type(type_)
-        )
+        ))
 
     def visit_create_index(self, create):
         preparer = self.preparer
@@ -1549,7 +1547,7 @@ class PGDDLCompiler(compiler.DDLCompiler):
             if concurrently:
                 text += "CONCURRENTLY "
 
-        text += "%s ON %s " % (
+        text += "{0!s} ON {1!s} ".format(
             self._prepared_index_name(index,
                                       include_schema=False),
             preparer.format_table(index.table)
@@ -1557,11 +1555,10 @@ class PGDDLCompiler(compiler.DDLCompiler):
 
         using = index.dialect_options['postgresql']['using']
         if using:
-            text += "USING %s " % preparer.quote(using)
+            text += "USING {0!s} ".format(preparer.quote(using))
 
         ops = index.dialect_options["postgresql"]["ops"]
-        text += "(%s)" \
-                % (
+        text += "({0!s})".format((
                     ', '.join([
                                   self.sql_compiler.process(
                                       expr.self_group()
@@ -1577,19 +1574,19 @@ class PGDDLCompiler(compiler.DDLCompiler):
                                   )
                                   for expr in index.expressions
                                   ])
-                )
+                ))
 
         withclause = index.dialect_options['postgresql']['with']
 
         if withclause:
-            text += " WITH (%s)" % (', '.join(
-                ['%s = %s' % storage_parameter
-                 for storage_parameter in withclause.items()]))
+            text += " WITH ({0!s})".format((', '.join(
+                ['{0!s} = {1!s}'.format(*storage_parameter)
+                 for storage_parameter in withclause.items()])))
 
         tablespace_name = index.dialect_options['postgresql']['tablespace']
 
         if tablespace_name:
-            text += " TABLESPACE %s" % preparer.quote(tablespace_name)
+            text += " TABLESPACE {0!s}".format(preparer.quote(tablespace_name))
 
         whereclause = index.dialect_options["postgresql"]["where"]
 
@@ -1616,20 +1613,20 @@ class PGDDLCompiler(compiler.DDLCompiler):
     def visit_exclude_constraint(self, constraint, **kw):
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                    self.preparer.format_constraint(constraint)
+            text += "CONSTRAINT {0!s} ".format( \
+                    self.preparer.format_constraint(constraint))
         elements = []
         for expr, name, op in constraint._render_exprs:
             kw['include_table'] = False
             elements.append(
-                "%s WITH %s" % (self.sql_compiler.process(expr, **kw), op)
+                "{0!s} WITH {1!s}".format(self.sql_compiler.process(expr, **kw), op)
             )
-        text += "EXCLUDE USING %s (%s)" % (constraint.using,
+        text += "EXCLUDE USING {0!s} ({1!s})".format(constraint.using,
                                            ', '.join(elements))
         if constraint.where is not None:
-            text += ' WHERE (%s)' % self.sql_compiler.process(
+            text += ' WHERE ({0!s})'.format(self.sql_compiler.process(
                 constraint.where,
-                literal_binds=True)
+                literal_binds=True))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -1653,12 +1650,12 @@ class PGDDLCompiler(compiler.DDLCompiler):
 
         if pg_opts['on_commit']:
             on_commit_options = pg_opts['on_commit'].replace("_", " ").upper()
-            table_opts.append('\n ON COMMIT %s' % on_commit_options)
+            table_opts.append('\n ON COMMIT {0!s}'.format(on_commit_options))
 
         if pg_opts['tablespace']:
             tablespace_name = pg_opts['tablespace']
             table_opts.append(
-                '\n TABLESPACE %s' % self.preparer.quote(tablespace_name)
+                '\n TABLESPACE {0!s}'.format(self.preparer.quote(tablespace_name))
             )
 
         return ''.join(table_opts)
@@ -1684,7 +1681,7 @@ class PGTypeCompiler(compiler.GenericTypeCompiler):
         if not type_.precision:
             return "FLOAT"
         else:
-            return "FLOAT(%(precision)s)" % {'precision': type_.precision}
+            return "FLOAT({precision!s})".format(**{'precision': type_.precision})
 
     def visit_DOUBLE_PRECISION(self, type_, **kw):
         return "DOUBLE PRECISION"
@@ -1732,22 +1729,22 @@ class PGTypeCompiler(compiler.GenericTypeCompiler):
         return self.dialect.identifier_preparer.format_type(type_)
 
     def visit_TIMESTAMP(self, type_, **kw):
-        return "TIMESTAMP%s %s" % (
-            getattr(type_, 'precision', None) and "(%d)" %
-            type_.precision or "",
+        return "TIMESTAMP{0!s} {1!s}".format(
+            getattr(type_, 'precision', None) and "({0:d})".format(
+            type_.precision) or "",
             (type_.timezone and "WITH" or "WITHOUT") + " TIME ZONE"
         )
 
     def visit_TIME(self, type_, **kw):
-        return "TIME%s %s" % (
-            getattr(type_, 'precision', None) and "(%d)" %
-            type_.precision or "",
+        return "TIME{0!s} {1!s}".format(
+            getattr(type_, 'precision', None) and "({0:d})".format(
+            type_.precision) or "",
             (type_.timezone and "WITH" or "WITHOUT") + " TIME ZONE"
         )
 
     def visit_INTERVAL(self, type_, **kw):
         if type_.precision is not None:
-            return "INTERVAL(%d)" % type_.precision
+            return "INTERVAL({0:d})".format(type_.precision)
         else:
             return "INTERVAL"
 
@@ -1755,9 +1752,9 @@ class PGTypeCompiler(compiler.GenericTypeCompiler):
         if type_.varying:
             compiled = "BIT VARYING"
             if type_.length is not None:
-                compiled += "(%d)" % type_.length
+                compiled += "({0:d})".format(type_.length)
         else:
-            compiled = "BIT(%d)" % type_.length
+            compiled = "BIT({0:d})".format(type_.length)
         return compiled
 
     def visit_UUID(self, type_, **kw):
@@ -1871,8 +1868,8 @@ class DropEnumType(schema._CreateDropBase):
 class PGExecutionContext(default.DefaultExecutionContext):
     def fire_sequence(self, seq, type_):
         return self._execute_scalar((
-            "select nextval('%s')" %
-            self.dialect.identifier_preparer.format_sequence(seq)), type_)
+            "select nextval('{0!s}')".format(
+            self.dialect.identifier_preparer.format_sequence(seq))), type_)
 
     def get_insert_default(self, column):
         if column.primary_key and \
@@ -1880,8 +1877,8 @@ class PGExecutionContext(default.DefaultExecutionContext):
             if column.server_default and column.server_default.has_argument:
 
                 # pre-execute passive defaults on primary key columns
-                return self._execute_scalar("select %s" %
-                                            column.server_default.arg,
+                return self._execute_scalar("select {0!s}".format(
+                                            column.server_default.arg),
                                             column.type)
 
             elif (column.default is None or
@@ -1899,7 +1896,7 @@ class PGExecutionContext(default.DefaultExecutionContext):
                     col = column.name
                     tab = tab[0:29 + max(0, (29 - len(col)))]
                     col = col[0:29 + max(0, (29 - len(tab)))]
-                    name = "%s_%s_seq" % (tab, col)
+                    name = "{0!s}_{1!s}_seq".format(tab, col)
                     column._postgresql_seq_name = seq_name = name
 
                 if column.table is not None:
@@ -1909,11 +1906,9 @@ class PGExecutionContext(default.DefaultExecutionContext):
                     effective_schema = None
 
                 if effective_schema is not None:
-                    exc = "select nextval('\"%s\".\"%s\"')" % \
-                          (effective_schema, seq_name)
+                    exc = "select nextval('\"{0!s}\".\"{1!s}\"')".format(effective_schema, seq_name)
                 else:
-                    exc = "select nextval('\"%s\"')" % \
-                          (seq_name,)
+                    exc = "select nextval('\"{0!s}\"')".format(seq_name)
 
                 return self._execute_scalar(exc, column.type)
 
@@ -2044,7 +2039,7 @@ class PGDialect(default.DefaultDialect):
         self.do_begin(connection.connection)
 
     def do_prepare_twophase(self, connection, xid):
-        connection.execute("PREPARE TRANSACTION '%s'" % xid)
+        connection.execute("PREPARE TRANSACTION '{0!s}'".format(xid))
 
     def do_rollback_twophase(self, connection, xid,
                              is_prepared=True, recover=False):
@@ -2055,7 +2050,7 @@ class PGDialect(default.DefaultDialect):
                 # Must find out a way how to make the dbapi not
                 # open a transaction.
                 connection.execute("ROLLBACK")
-            connection.execute("ROLLBACK PREPARED '%s'" % xid)
+            connection.execute("ROLLBACK PREPARED '{0!s}'".format(xid))
             connection.execute("BEGIN")
             self.do_rollback(connection.connection)
         else:
@@ -2066,7 +2061,7 @@ class PGDialect(default.DefaultDialect):
         if is_prepared:
             if recover:
                 connection.execute("ROLLBACK")
-            connection.execute("COMMIT PREPARED '%s'" % xid)
+            connection.execute("COMMIT PREPARED '{0!s}'".format(xid))
             connection.execute("BEGIN")
             self.do_rollback(connection.connection)
         else:
@@ -2198,7 +2193,7 @@ class PGDialect(default.DefaultDialect):
             v)
         if not m:
             raise AssertionError(
-                "Could not determine version from string '%s'" % v)
+                "Could not determine version from string '{0!s}'".format(v))
         return tuple([int(x) for x in m.group(1, 2, 3) if x is not None])
 
     @reflection.cache
@@ -2219,9 +2214,9 @@ class PGDialect(default.DefaultDialect):
             SELECT c.oid
             FROM pg_catalog.pg_class c
             LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-            WHERE (%s)
+            WHERE ({0!s})
             AND c.relname = :table_name AND c.relkind in ('r', 'v', 'm', 'f')
-        """ % schema_where_clause
+        """.format(schema_where_clause)
         # Since we're binding to unicode, table_name and schema_name must be
         # unicode.
         table_name = util.text_type(table_name)
@@ -2287,7 +2282,7 @@ class PGDialect(default.DefaultDialect):
             sql.text("SELECT c.relname FROM pg_class c "
                      "JOIN pg_namespace n ON n.oid = c.relnamespace "
                      "WHERE n.nspname = :schema AND c.relkind IN (%s)" %
-                     (", ".join("'%s'" % elem for elem in kinds))
+                     (", ".join("'{0!s}'".format(elem) for elem in kinds))
                      ).columns(relname=sqltypes.Unicode),
             schema=schema if schema is not None else self.default_schema_name)
         return [name for name, in result]
@@ -2335,7 +2330,7 @@ class PGDialect(default.DefaultDialect):
         domains = self._load_domains(connection)
         enums = dict(
             (
-                "%s.%s" % (rec['schema'], rec['name'])
+                "{0!s}.{1!s}".format(rec['schema'], rec['name'])
                 if not rec['visible'] else rec['name'], rec) for rec in
             self._load_enums(connection, schema='*')
         )
@@ -2436,8 +2431,7 @@ class PGDialect(default.DefaultDialect):
             if is_array:
                 coltype = self.ischema_names['_array'](coltype)
         else:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (attype, name))
+            util.warn("Did not recognize type '{0!s}' of column '{1!s}'".format(attype, name))
             coltype = sqltypes.NULLTYPE
         # adjust the default value
         autoincrement = False
@@ -2452,7 +2446,7 @@ class PGDialect(default.DefaultDialect):
                     # later be enhanced to obey quoting rules /
                     # "quote schema"
                     default = match.group(1) + \
-                              ('"%s"' % sch) + '.' + \
+                              ('"{0!s}"'.format(sch)) + '.' + \
                               match.group(2) + match.group(3)
 
         column_info = dict(name=name, type=coltype, nullable=nullable,
@@ -2471,11 +2465,11 @@ class PGDialect(default.DefaultDialect):
                     pg_class t
                     join pg_index ix on t.oid = ix.indrelid
                     join pg_attribute a
-                        on t.oid=a.attrelid AND %s
+                        on t.oid=a.attrelid AND {0!s}
                  WHERE
                   t.oid = :table_oid and ix.indisprimary = 't'
                 ORDER BY a.attnum
-            """ % self._pg_index_any("a.attnum", "ix.indkey")
+            """.format(self._pg_index_any("a.attnum", "ix.indkey"))
 
         else:
             # unnest() and generate_subscripts() both introduced in
@@ -2606,12 +2600,12 @@ class PGDialect(default.DefaultDialect):
             # pre-8.1 releases, so I think you're kinda stuck with the above
             # for now.
             # regards, tom lane"
-            return "(%s)" % " OR ".join(
-                "%s[%d] = %s" % (compare_to, ind, col)
+            return "({0!s})".format(" OR ".join(
+                "{0!s}[{1:d}] = {2!s}".format(compare_to, ind, col)
                 for ind in range(0, 10)
-            )
+            ))
         else:
-            return "%s = ANY(%s)" % (col, compare_to)
+            return "{0!s} = ANY({1!s})".format(col, compare_to)
 
     @reflection.cache
     def get_indexes(self, connection, table_name, schema, **kw):
@@ -2626,15 +2620,15 @@ class PGDialect(default.DefaultDialect):
               SELECT
                   i.relname as relname,
                   ix.indisunique, ix.indexprs, ix.indpred,
-                  a.attname, a.attnum, NULL, ix.indkey%s,
-                  %s, am.amname
+                  a.attname, a.attnum, NULL, ix.indkey{0!s},
+                  {1!s}, am.amname
               FROM
                   pg_class t
                         join pg_index ix on t.oid = ix.indrelid
                         join pg_class i on i.oid = ix.indexrelid
                         left outer join
                             pg_attribute a
-                            on t.oid = a.attrelid and %s
+                            on t.oid = a.attrelid and {2!s}
                         left outer join
                             pg_am am
                             on i.relam = am.oid
@@ -2645,7 +2639,7 @@ class PGDialect(default.DefaultDialect):
               ORDER BY
                   t.relname,
                   i.relname
-            """ % (
+            """.format(
                 # version 8.3 here was based on observing the
                 # cast does not work in PG 8.2.4, does work in 8.3.0.
                 # nothing in PG changelogs regarding this.
@@ -2708,8 +2702,7 @@ class PGDialect(default.DefaultDialect):
 
             if prd and not idx_name == sv_idx_name:
                 util.warn(
-                    "Predicate of partial index %s ignored during reflection"
-                    % idx_name)
+                    "Predicate of partial index {0!s} ignored during reflection".format(idx_name))
                 sv_idx_name = idx_name
 
             has_idx = idx_name in indexes
@@ -2891,7 +2884,7 @@ class PGDialect(default.DefaultDialect):
                 # it will be prefixed with the schema-name when it's used.
                 name = domain['name']
             else:
-                name = "%s.%s" % (domain['schema'], domain['name'])
+                name = "{0!s}.{1!s}".format(domain['schema'], domain['name'])
 
             domains[name] = {
                 'attype': attype,

--- a/lib/sqlalchemy/dialects/postgresql/hstore.py
+++ b/lib/sqlalchemy/dialects/postgresql/hstore.py
@@ -348,7 +348,7 @@ def _parse_error(hstore_str, pos):
     if len(residual) > ctx:
         residual = residual[:-1] + '[...]'
 
-    return "After %r, could not parse residual at position %d: %r" % (
+    return "After {0!r}, could not parse residual at position {1:d}: {2!r}".format(
         parsed_tail, pos, residual)
 
 
@@ -402,10 +402,9 @@ def _serialize_hstore(val):
         if position == 'value' and s is None:
             return 'NULL'
         elif isinstance(s, util.string_types):
-            return '"%s"' % s.replace("\\", "\\\\").replace('"', r'\"')
+            return '"{0!s}"'.format(s.replace("\\", "\\\\").replace('"', r'\"'))
         else:
-            raise ValueError("%r in %s position is not a string." %
-                             (s, position))
+            raise ValueError("{0!r} in {1!s} position is not a string.".format(s, position))
 
-    return ', '.join('%s=>%s' % (esc(k, 'key'), esc(v, 'value'))
+    return ', '.join('{0!s}=>{1!s}'.format(esc(k, 'key'), esc(v, 'value'))
                      for k, v in val.items())

--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -53,7 +53,7 @@ class JSONPathType(sqltypes.JSON.JSONPathType):
         def process(value):
             assert isinstance(value, collections.Sequence)
             tokens = [util.text_type(elem) for elem in value]
-            value = "{%s}" % (", ".join(tokens))
+            value = "{{{0!s}}}".format((", ".join(tokens)))
             if super_proc:
                 value = super_proc(value)
             return value
@@ -66,7 +66,7 @@ class JSONPathType(sqltypes.JSON.JSONPathType):
         def process(value):
             assert isinstance(value, collections.Sequence)
             tokens = [util.text_type(elem) for elem in value]
-            value = "{%s}" % (", ".join(tokens))
+            value = "{{{0!s}}}".format((", ".join(tokens)))
             if super_proc:
                 value = super_proc(value)
             return value

--- a/lib/sqlalchemy/dialects/postgresql/pg8000.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg8000.py
@@ -86,7 +86,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # pg8000 returns float natively for 701
@@ -95,7 +95,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGNumericNoBind(_PGNumeric):

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -348,7 +348,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # pg8000 returns float natively for 701
@@ -357,7 +357,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGEnum(ENUM):
@@ -457,7 +457,7 @@ class PGExecutionContext_psycopg2(PGExecutionContext):
         if is_server_side:
             # use server-side cursors:
             # http://lists.initd.org/pipermail/psycopg/2007-January/005251.html
-            ident = "c_%s_%s" % (hex(id(self))[2:],
+            ident = "c_{0!s}_{1!s}".format(hex(id(self))[2:],
                                  hex(_server_side_id())[2:])
             return self._dbapi_connection.cursor(ident)
         else:

--- a/lib/sqlalchemy/dialects/postgresql/pygresql.py
+++ b/lib/sqlalchemy/dialects/postgresql/pygresql.py
@@ -43,7 +43,7 @@ class _PGNumeric(Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # PyGreSQL returns float natively for 701 (float8)
@@ -52,7 +52,7 @@ class _PGNumeric(Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGHStore(HSTORE):
@@ -212,7 +212,7 @@ class PGDialect_pygresql(PGDialect):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if 'port' in opts:
-            opts['host'] = '%s:%s' % (
+            opts['host'] = '{0!s}:{1!s}'.format(
                 opts.get('host', '').rsplit(':', 1)[0], opts.pop('port'))
         opts.update(url.query)
         return [], opts

--- a/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
@@ -97,10 +97,10 @@ class SQLiteDialect_pysqlcipher(SQLiteDialect_pysqlite):
 
         conn = super(SQLiteDialect_pysqlcipher, self). \
             connect(*cargs, **cparams)
-        conn.execute('pragma key="%s"' % passphrase)
+        conn.execute('pragma key="{0!s}"'.format(passphrase))
         for prag, value in pragmas.items():
             if value is not None:
-                conn.execute('pragma %s=%s' % (prag, value))
+                conn.execute('pragma {0!s}={1!s}'.format(prag, value))
 
         return conn
 

--- a/lib/sqlalchemy/dialects/sybase/base.py
+++ b/lib/sqlalchemy/dialects/sybase/base.py
@@ -157,10 +157,10 @@ class SybaseTypeCompiler(compiler.GenericTypeCompiler):
         return self.visit_NVARCHAR(type_)
 
     def visit_UNICHAR(self, type_, **kw):
-        return "UNICHAR(%d)" % type_.length
+        return "UNICHAR({0:d})".format(type_.length)
 
     def visit_UNIVARCHAR(self, type_, **kw):
-        return "UNIVARCHAR(%d)" % type_.length
+        return "UNIVARCHAR({0:d})".format(type_.length)
 
     def visit_UNITEXT(self, type_, **kw):
         return "UNITEXT"
@@ -275,8 +275,8 @@ class SybaseExecutionContext(default.DefaultExecutionContext):
 
             if self._enable_identity_insert:
                 self.cursor.execute(
-                    "SET IDENTITY_INSERT %s ON" %
-                    self.dialect.identifier_preparer.format_table(tbl))
+                    "SET IDENTITY_INSERT {0!s} ON".format(
+                    self.dialect.identifier_preparer.format_table(tbl)))
 
         if self.isddl:
             # TODO: to enhance this, we can detect "ddl in tran" on the
@@ -300,9 +300,9 @@ class SybaseExecutionContext(default.DefaultExecutionContext):
 
         if self._enable_identity_insert:
             self.cursor.execute(
-                "SET IDENTITY_INSERT %s OFF" %
+                "SET IDENTITY_INSERT {0!s} OFF".format(
                 self.dialect.identifier_preparer.
-                format_table(self.compiled.statement.table)
+                format_table(self.compiled.statement.table))
             )
 
     def get_lastrowid(self):
@@ -334,7 +334,7 @@ class SybaseSQLCompiler(compiler.SQLCompiler):
             # s += "FIRST "
             # else:
             # s += "TOP %s " % (select._limit,)
-            s += "TOP %s " % (limit,)
+            s += "TOP {0!s} ".format(limit)
         offset = select._offset
         if offset:
             raise NotImplementedError("Sybase ASE does not support OFFSET")
@@ -349,7 +349,7 @@ class SybaseSQLCompiler(compiler.SQLCompiler):
 
     def visit_extract(self, extract, **kw):
         field = self.extract_map.get(extract.field, extract.field)
-        return 'DATEPART("%s", %s)' % (
+        return 'DATEPART("{0!s}", {1!s})'.format(
             field, self.process(extract.expr, **kw))
 
     def visit_now_func(self, fn, **kw):
@@ -396,7 +396,7 @@ class SybaseDDLCompiler(compiler.DDLCompiler):
                 colspec += " IDENTITY"
             else:
                 # TODO: need correct syntax for this
-                colspec += " IDENTITY(%s,%s)" % (start, increment)
+                colspec += " IDENTITY({0!s},{1!s})".format(start, increment)
         else:
             default = self.get_column_default_string(column)
             if default is not None:
@@ -412,7 +412,7 @@ class SybaseDDLCompiler(compiler.DDLCompiler):
 
     def visit_drop_index(self, drop):
         index = drop.element
-        return "\nDROP INDEX %s.%s" % (
+        return "\nDROP INDEX {0!s}.{1!s}".format(
             self.preparer.quote_identifier(index.table.name),
             self._prepared_index_name(drop.element,
                                       include_schema=False)
@@ -548,8 +548,7 @@ class SybaseDialect(default.DefaultDialect):
             # if is_array:
             #     coltype = ARRAY(coltype)
         else:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (type_, name))
+            util.warn("Did not recognize type '{0!s}' of column '{1!s}'".format(type_, name))
             coltype = sqltypes.NULLTYPE
 
         if default:
@@ -639,8 +638,8 @@ class SybaseDialect(default.DefaultDialect):
             constrained_columns = []
             referred_columns = []
             for i in range(1, r["count"] + 1):
-                constrained_columns.append(columns[r["fokey%i" % i]])
-                referred_columns.append(reftable_columns[r["refkey%i" % i]])
+                constrained_columns.append(columns[r["fokey{0:d}".format(i)]])
+                referred_columns.append(reftable_columns[r["refkey{0:d}".format(i)]])
 
             fk_info = {
                 "constrained_columns": constrained_columns,
@@ -692,7 +691,7 @@ class SybaseDialect(default.DefaultDialect):
         for r in results:
             column_names = []
             for i in range(1, r["count"]):
-                column_names.append(r["col_%i" % (i,)])
+                column_names.append(r["col_{0:d}".format(i)])
             index_info = {"name": r["name"],
                           "unique": bool(r["unique"]),
                           "column_names": column_names}
@@ -739,7 +738,7 @@ class SybaseDialect(default.DefaultDialect):
         constrained_columns = []
         if pks:
             for i in range(1, pks["count"] + 1):
-                constrained_columns.append(pks["pk_%i" % (i,)])
+                constrained_columns.append(pks["pk_{0:d}".format(i)])
             return {"constrained_columns": constrained_columns,
                     "name": pks["name"]}
         else:

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -734,7 +734,7 @@ class Connection(Connectable):
 
         if name is None:
             self.__savepoint_seq += 1
-            name = 'sa_savepoint_%s' % self.__savepoint_seq
+            name = 'sa_savepoint_{0!s}'.format(self.__savepoint_seq)
         if self._still_open_and_connection_is_valid:
             self.engine.dialect.do_savepoint(self, name)
             return name
@@ -1868,7 +1868,7 @@ class Engine(Connectable, log.Identified):
     echo = log.echo_property()
 
     def __repr__(self):
-        return 'Engine(%r)' % self.url
+        return 'Engine({0!r})'.format(self.url)
 
     def dispose(self):
         """Dispose of the connection pool used by this :class:`.Engine`.

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -175,8 +175,8 @@ class DefaultDialect(interfaces.Dialect):
 
         if not getattr(self, 'ported_sqla_06', True):
             util.warn(
-                "The %s dialect is not yet ported to the 0.6 format" %
-                self.name)
+                "The {0!s} dialect is not yet ported to the 0.6 format".format(
+                self.name))
 
         self.convert_unicode = convert_unicode
         self.encoding = encoding
@@ -377,8 +377,7 @@ class DefaultDialect(interfaces.Dialect):
     def validate_identifier(self, ident):
         if len(ident) > self.max_identifier_length:
             raise exc.IdentifierError(
-                "Identifier '%s' exceeds maximum length of %d characters" %
-                (ident, self.max_identifier_length)
+                "Identifier '{0!s}' exceeds maximum length of {1:d} characters".format(ident, self.max_identifier_length)
             )
 
     def connect(self, *cargs, **cparams):
@@ -444,7 +443,7 @@ class DefaultDialect(interfaces.Dialect):
         do_commit_twophase().  Its format is unspecified.
         """
 
-        return "_sa_%032x" % random.randint(0, 2 ** 128)
+        return "_sa_{0:032x}".format(random.randint(0, 2 ** 128))
 
     def do_savepoint(self, connection, name):
         connection.execute(expression.SavepointClause(name))

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -753,8 +753,7 @@ class Inspector(object):
             if include_columns and \
                     not set(columns).issubset(include_columns):
                 util.warn(
-                    "Omitting %s key for (%s), key covers omitted columns." %
-                    (flavor, ', '.join(columns)))
+                    "Omitting {0!s} key for ({1!s}), key covers omitted columns.".format(flavor, ', '.join(columns)))
                 continue
             if duplicates:
                 continue

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -565,8 +565,8 @@ class ResultMetaData(object):
         if result is None:
             if raiseerr:
                 raise exc.NoSuchColumnError(
-                    "Could not locate column in row for column '%s'" %
-                    expression._string_or_unprintable(key))
+                    "Could not locate column in row for column '{0!s}'".format(
+                    expression._string_or_unprintable(key)))
             else:
                 return None
         else:

--- a/lib/sqlalchemy/engine/strategies.py
+++ b/lib/sqlalchemy/engine/strategies.py
@@ -143,7 +143,7 @@ class DefaultEngineStrategy(EngineStrategy):
                 "Invalid argument(s) %s sent to create_engine(), "
                 "using configuration %s/%s/%s.  Please check that the "
                 "keyword arguments are appropriate for this combination "
-                "of components." % (','.join("'%s'" % k for k in kwargs),
+                "of components." % (','.join("'{0!s}'".format(k) for k in kwargs),
                                     dialect.__class__.__name__,
                                     pool.__class__.__name__,
                                     engineclass.__name__))

--- a/lib/sqlalchemy/engine/threadlocal.py
+++ b/lib/sqlalchemy/engine/threadlocal.py
@@ -134,4 +134,4 @@ class TLEngine(base.Engine):
             self._connections.trans = []
 
     def __repr__(self):
-        return 'TLEngine(%s)' % str(self.url)
+        return 'TLEngine({0!s})'.format(str(self.url))

--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -73,7 +73,7 @@ class URL(object):
             s += "@"
         if self.host is not None:
             if ':' in self.host:
-                s += "[%s]" % self.host
+                s += "[{0!s}]".format(self.host)
             else:
                 s += self.host
         if self.port is not None:
@@ -83,7 +83,7 @@ class URL(object):
         if self.query:
             keys = list(self.query)
             keys.sort()
-            s += '?' + "&".join("%s=%s" % (k, self.query[k]) for k in keys)
+            s += '?' + "&".join("{0!s}={1!s}".format(k, self.query[k]) for k in keys)
         return s
 
     def __str__(self):
@@ -241,11 +241,11 @@ def _parse_rfc1738_args(name):
         return URL(name, **components)
     else:
         raise exc.ArgumentError(
-            "Could not parse rfc1738 URL from string '%s'" % name)
+            "Could not parse rfc1738 URL from string '{0!s}'".format(name))
 
 
 def _rfc_1738_quote(text):
-    return re.sub(r'[:@/]', lambda m: "%%%X" % ord(m.group(0)), text)
+    return re.sub(r'[:@/]', lambda m: "%{0:X}".format(ord(m.group(0))), text)
 
 
 def _rfc_1738_unquote(text):

--- a/lib/sqlalchemy/event/api.py
+++ b/lib/sqlalchemy/event/api.py
@@ -24,8 +24,7 @@ def _event_key(target, identifier, fn):
         if tgt is not None:
             return _EventKey(target, identifier, fn, tgt)
     else:
-        raise exc.InvalidRequestError("No such event '%s' for target '%s'" %
-                                      (identifier, target))
+        raise exc.InvalidRequestError("No such event '{0!s}' for target '{1!s}'".format(identifier, target))
 
 
 def listen(target, identifier, fn, *args, **kw):

--- a/lib/sqlalchemy/event/base.py
+++ b/lib/sqlalchemy/event/base.py
@@ -122,7 +122,7 @@ class _Dispatch(object):
         """
         if '_joined_dispatch_cls' not in self.__class__.__dict__:
             cls = type(
-                "Joined%s" % self.__class__.__name__,
+                "Joined{0!s}".format(self.__class__.__name__),
                 (_JoinedDispatcher,), {'__slots__': self._event_names}
             )
 
@@ -168,7 +168,7 @@ def _create_dispatcher_class(cls, classname, bases, dict_):
         dispatch_base = _Dispatch
 
     event_names = [k for k in dict_ if _is_event_name(k)]
-    dispatch_cls = type("%sDispatch" % classname,
+    dispatch_cls = type("{0!s}Dispatch".format(classname),
                         (dispatch_base,), {'__slots__': event_names})
 
     dispatch_cls._event_names = event_names

--- a/lib/sqlalchemy/event/legacy.py
+++ b/lib/sqlalchemy/event/legacy.py
@@ -62,7 +62,7 @@ def _indent(text, indent):
 def _standard_listen_example(dispatch_collection, sample_target, fn):
     example_kw_arg = _indent(
         "\n".join(
-            "%(arg)s = kw['%(arg)s']" % {"arg": arg}
+            "{arg!s} = kw['{arg!s}']".format(**{"arg": arg})
             for arg in dispatch_collection.arg_names[0:2]
         ),
         "    ")
@@ -94,8 +94,8 @@ def _standard_listen_example(dispatch_collection, sample_target, fn):
         )
 
     text %= {
-        "current_since": " (arguments as of %s)" %
-                         current_since if current_since else "",
+        "current_since": " (arguments as of {0!s})".format(
+                         current_since) if current_since else "",
         "event_name": fn.__name__,
         "has_kw_arguments": ", **kw" if dispatch_collection.has_kw else "",
         "named_event_arguments": ", ".join(dispatch_collection.arg_names),

--- a/lib/sqlalchemy/event/registry.py
+++ b/lib/sqlalchemy/event/registry.py
@@ -207,8 +207,7 @@ class _EventKey(object):
 
         if key not in _key_to_collection:
             raise exc.InvalidRequestError(
-                "No listeners found for event %s / %r / %s " %
-                (self.target, self.identifier, self.fn)
+                "No listeners found for event {0!s} / {1!r} / {2!s} ".format(self.target, self.identifier, self.fn)
             )
         dispatch_reg = _key_to_collection.pop(key)
 

--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -36,7 +36,7 @@ class ObjectNotExecutableError(ArgumentError):
 
     def __init__(self, target):
         super(ObjectNotExecutableError, self).__init__(
-            "Not an executable object: %r" % target
+            "Not an executable object: {0!r}".format(target)
         )
 
 
@@ -75,7 +75,7 @@ class CircularDependencyError(SQLAlchemyError):
 
     def __init__(self, message, cycles, edges, msg=None):
         if msg is None:
-            message += " (%s)" % ", ".join(repr(s) for s in cycles)
+            message += " ({0!s})".format(", ".join(repr(s) for s in cycles))
         else:
             message = msg
         SQLAlchemyError.__init__(self, message)
@@ -101,8 +101,7 @@ class UnsupportedCompilationError(CompileError):
 
     def __init__(self, compiler, element_type):
         super(UnsupportedCompilationError, self).__init__(
-            "Compiler %r can't render element of type %s" %
-            (compiler, element_type))
+            "Compiler {0!r} can't render element of type {1!s}".format(compiler, element_type))
 
 
 class IdentifierError(SQLAlchemyError):
@@ -256,12 +255,12 @@ class StatementError(SQLAlchemyError):
 
         details = [SQLAlchemyError.__str__(self)]
         if self.statement:
-            details.append("[SQL: %r]" % self.statement)
+            details.append("[SQL: {0!r}]".format(self.statement))
             if self.params:
                 params_repr = util._repr_params(self.params, 10)
-                details.append("[parameters: %r]" % params_repr)
+                details.append("[parameters: {0!r}]".format(params_repr))
         return ' '.join([
-                            "(%s)" % det for det in self.detail
+                            "({0!s})".format(det) for det in self.detail
                             ] + details)
 
     def __unicode__(self):
@@ -308,8 +307,7 @@ class DBAPIError(StatementError):
             # raise a StatementError
             if not isinstance(orig, dbapi_base_err) and statement:
                 return StatementError(
-                    "(%s.%s) %s" %
-                    (orig.__class__.__module__, orig.__class__.__name__,
+                    "({0!s}.{1!s}) {2!s}".format(orig.__class__.__module__, orig.__class__.__name__,
                      orig),
                     statement, params, orig
                 )
@@ -337,8 +335,8 @@ class DBAPIError(StatementError):
             text = 'Error in str() of DB-API-generated exception: ' + str(e)
         StatementError.__init__(
             self,
-            '(%s.%s) %s' % (
-                orig.__class__.__module__, orig.__class__.__name__, text,),
+            '({0!s}.{1!s}) {2!s}'.format(
+                orig.__class__.__module__, orig.__class__.__name__, text),
             statement,
             params,
             orig

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -152,7 +152,7 @@ class AssociationProxy(interfaces.InspectionAttrInfo):
         self.proxy_bulk_set = proxy_bulk_set
 
         self.owning_class = None
-        self.key = '_%s_%s_%s' % (
+        self.key = '_{0!s}_{1!s}_{2!s}'.format(
             type(self).__name__, target_collection, id(self))
         self.collection_class = None
         if info:
@@ -709,7 +709,7 @@ class _AssociationList(_AssociationCollection):
         return repr(list(self))
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and
@@ -834,8 +834,8 @@ class _AssociationDict(_AssociationCollection):
 
     def update(self, *a, **kw):
         if len(a) > 1:
-            raise TypeError('update expected at most 1 arguments, got %i' %
-                            len(a))
+            raise TypeError('update expected at most 1 arguments, got {0:d}'.format(
+                            len(a)))
         elif len(a) == 1:
             seq_or_map = a[0]
             # discern dict from sequence - took the advice from
@@ -860,7 +860,7 @@ class _AssociationDict(_AssociationCollection):
         return dict(self.items())
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and
@@ -1060,7 +1060,7 @@ class _AssociationSet(_AssociationCollection):
         return repr(set(self))
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and

--- a/lib/sqlalchemy/ext/automap.py
+++ b/lib/sqlalchemy/ext/automap.py
@@ -656,7 +656,7 @@ def generate_relationship(
     elif return_fn is relationship:
         return return_fn(referred_cls, **kw)
     else:
-        raise TypeError("Unknown relationship function: %s" % return_fn)
+        raise TypeError("Unknown relationship function: {0!s}".format(return_fn))
 
 
 class AutomapBase(object):

--- a/lib/sqlalchemy/ext/declarative/base.py
+++ b/lib/sqlalchemy/ext/declarative/base.py
@@ -644,8 +644,7 @@ def _declarative_constructor(self, **kwargs):
     for k in kwargs:
         if not hasattr(cls_, k):
             raise TypeError(
-                "%r is an invalid keyword argument for %s" %
-                (k, cls_.__name__))
+                "{0!r} is an invalid keyword argument for {1!s}".format(k, cls_.__name__))
         setattr(self, k, kwargs[k])
 
 

--- a/lib/sqlalchemy/ext/declarative/clsregistry.py
+++ b/lib/sqlalchemy/ext/declarative/clsregistry.py
@@ -210,8 +210,7 @@ class _GetColumns(object):
         if mp:
             if key not in mp.all_orm_descriptors:
                 raise exc.InvalidRequestError(
-                    "Class %r does not have a mapped column named %r"
-                    % (self.cls, key))
+                    "Class {0!r} does not have a mapped column named {1!r}".format(self.cls, key))
 
             desc = mp.all_orm_descriptors[key]
             if desc.extension_type is interfaces.NOT_EXTENSION:

--- a/lib/sqlalchemy/ext/orderinglist.py
+++ b/lib/sqlalchemy/ext/orderinglist.py
@@ -182,7 +182,7 @@ def count_from_n_factory(start):
         return index + start
 
     try:
-        f.__name__ = 'count_from_%i' % start
+        f.__name__ = 'count_from_{0:d}'.format(start)
     except TypeError:
         pass
     return f

--- a/lib/sqlalchemy/ext/serializer.py
+++ b/lib/sqlalchemy/ext/serializer.py
@@ -141,7 +141,7 @@ def Deserializer(file, metadata=None, scoped_session=None, engine=None):
             elif type_ == "engine":
                 return get_engine()
             else:
-                raise Exception("Unknown token: %s" % type_)
+                raise Exception("Unknown token: {0!s}".format(type_))
 
     unpickler.persistent_load = persistent_load
     return unpickler

--- a/lib/sqlalchemy/log.py
+++ b/lib/sqlalchemy/log.py
@@ -174,11 +174,11 @@ def instance_logger(instance, echoflag=None):
     """create a logger for an instance that implements :class:`.Identified`."""
 
     if instance.logging_name:
-        name = "%s.%s.%s" % (instance.__class__.__module__,
+        name = "{0!s}.{1!s}.{2!s}".format(instance.__class__.__module__,
                              instance.__class__.__name__,
                              instance.logging_name)
     else:
-        name = "%s.%s" % (instance.__class__.__module__,
+        name = "{0!s}.{1!s}".format(instance.__class__.__module__,
                           instance.__class__.__name__)
 
     instance._echo = echoflag

--- a/lib/sqlalchemy/orm/attributes.py
+++ b/lib/sqlalchemy/orm/attributes.py
@@ -194,7 +194,7 @@ class QueryableAttribute(interfaces._MappedAttribute,
             )
 
     def __str__(self):
-        return "%s.%s" % (self.class_.__name__, self.key)
+        return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
     @util.memoized_property
     def property(self):
@@ -293,7 +293,7 @@ def create_proxied_attribute(descriptor):
                 return self.descriptor.__get__(instance, owner)
 
         def __str__(self):
-            return "%s.%s" % (self.class_.__name__, self.key)
+            return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
         def __getattr__(self, attribute):
             """Delegate __getattr__ to the original descriptor and/or
@@ -460,7 +460,7 @@ class AttributeImpl(object):
     )
 
     def __str__(self):
-        return "%s.%s" % (self.class_.__name__, self.key)
+        return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
     def _get_active_history(self):
         """Backwards compat for impl.active_history"""
@@ -803,7 +803,7 @@ class ScalarObjectAttributeImpl(ScalarAttributeImpl):
                 return
             else:
                 raise ValueError(
-                    "Object %s not associated with %s on attribute '%s'" % (
+                    "Object {0!s} not associated with {1!s} on attribute '{2!s}'".format(
                         instance_str(check_old),
                         state_str(state),
                         self.key
@@ -1044,7 +1044,7 @@ class CollectionAttributeImpl(AttributeImpl):
                             iterable.__class__.__name__
                     wanted = self._duck_typed_as.__name__
                     raise TypeError(
-                        "Incompatible collection type: %s is not %s-like" % (
+                        "Incompatible collection type: {0!s} is not {1!s}-like".format(
                             given, wanted))
 
                 # If the object is an adapted collection, return the (iterable)

--- a/lib/sqlalchemy/orm/base.py
+++ b/lib/sqlalchemy/orm/base.py
@@ -227,7 +227,7 @@ def state_str(state):
     if state is None:
         return "None"
     else:
-        return '<%s at 0x%x>' % (state.class_.__name__, id(state.obj()))
+        return '<{0!s} at 0x{1:x}>'.format(state.class_.__name__, id(state.obj()))
 
 
 def state_class_str(state):
@@ -238,7 +238,7 @@ def state_class_str(state):
     if state is None:
         return "None"
     else:
-        return '<%s>' % (state.class_.__name__,)
+        return '<{0!s}>'.format(state.class_.__name__)
 
 
 def attribute_str(instance, attribute):
@@ -381,8 +381,7 @@ def _entity_descriptor(entity, key):
         return getattr(entity, key)
     except AttributeError:
         raise sa_exc.InvalidRequestError(
-            "Entity '%s' has no property '%s'" %
-            (description, key)
+            "Entity '{0!s}' has no property '{1!s}'".format(description, key)
         )
 
 
@@ -425,7 +424,7 @@ def class_mapper(class_, configure=True):
     if mapper is None:
         if not isinstance(class_, type):
             raise sa_exc.ArgumentError(
-                "Class object expected, got '%r'." % (class_,))
+                "Class object expected, got '{0!r}'.".format(class_))
         raise exc.UnmappedClassError(class_)
     else:
         return mapper

--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -821,7 +821,7 @@ def __converting_factory(specimen_cls, original_factory):
         return instrumented_cls(collection)
 
     # often flawed but better than nothing
-    wrapper.__name__ = "%sWrapper" % original_factory.__name__
+    wrapper.__name__ = "{0!s}Wrapper".format(original_factory.__name__)
     wrapper.__doc__ = original_factory.__doc__
 
     return wrapper
@@ -946,7 +946,7 @@ def _set_collection_attributes(cls, roles, methods):
                                                before, argument, after))
     # intern the role map
     for role, method_name in roles.items():
-        setattr(cls, '_sa_%s' % role, getattr(cls, method_name))
+        setattr(cls, '_sa_{0!s}'.format(role), getattr(cls, method_name))
 
     cls._sa_adapter = None
 
@@ -977,7 +977,7 @@ def _instrument_membership_mutator(method, before, argument, after):
             if pos_arg is None:
                 if named_arg not in kw:
                     raise sa_exc.ArgumentError(
-                        "Missing argument %s" % argument)
+                        "Missing argument {0!s}".format(argument))
                 value = kw[named_arg]
             else:
                 if len(args) > pos_arg:
@@ -986,7 +986,7 @@ def _instrument_membership_mutator(method, before, argument, after):
                     value = kw[named_arg]
                 else:
                     raise sa_exc.ArgumentError(
-                        "Missing argument %s" % argument)
+                        "Missing argument {0!s}".format(argument))
 
         initiator = kw.pop('_sa_initiator', None)
         if initiator is False:

--- a/lib/sqlalchemy/orm/dependency.py
+++ b/lib/sqlalchemy/orm/dependency.py
@@ -316,7 +316,7 @@ class DependencyProcessor(object):
         raise NotImplementedError()
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.prop)
+        return "{0!s}({1!s})".format(self.__class__.__name__, self.prop)
 
 
 class OneToManyDP(DependencyProcessor):

--- a/lib/sqlalchemy/orm/deprecated_interfaces.py
+++ b/lib/sqlalchemy/orm/deprecated_interfaces.py
@@ -117,7 +117,7 @@ class MapperExtension(object):
                     event.listen(self.class_manager, 'init_failure',
                                  go(ls_meth), raw=False, propagate=True)
                 else:
-                    event.listen(self, "%s" % meth, ls_meth,
+                    event.listen(self, "{0!s}".format(meth), ls_meth,
                                  raw=False, retval=True, propagate=True)
 
     def instrument_class(self, mapper, class_):

--- a/lib/sqlalchemy/orm/evaluator.py
+++ b/lib/sqlalchemy/orm/evaluator.py
@@ -30,10 +30,10 @@ class EvaluatorCompiler(object):
         self.target_cls = target_cls
 
     def process(self, clause):
-        meth = getattr(self, "visit_%s" % clause.__visit_name__, None)
+        meth = getattr(self, "visit_{0!s}".format(clause.__visit_name__), None)
         if not meth:
             raise UnevaluatableError(
-                "Cannot evaluate %s" % type(clause).__name__)
+                "Cannot evaluate {0!s}".format(type(clause).__name__))
         return meth(clause)
 
     def visit_grouping(self, clause):
@@ -54,8 +54,8 @@ class EvaluatorCompiler(object):
             if self.target_cls and not issubclass(
                     self.target_cls, parentmapper.class_):
                 raise UnevaluatableError(
-                    "Can't evaluate criteria against alternate class %s" %
-                    parentmapper.class_
+                    "Can't evaluate criteria against alternate class {0!s}".format(
+                    parentmapper.class_)
                 )
             key = parentmapper._columntoproperty[clause].key
         else:
@@ -88,8 +88,8 @@ class EvaluatorCompiler(object):
                 return True
         else:
             raise UnevaluatableError(
-                "Cannot evaluate clauselist with operator %s" %
-                clause.operator)
+                "Cannot evaluate clauselist with operator {0!s}".format(
+                clause.operator))
 
         return evaluate
 
@@ -112,8 +112,7 @@ class EvaluatorCompiler(object):
                 return operator(eval_left(obj), eval_right(obj))
         else:
             raise UnevaluatableError(
-                "Cannot evaluate %s with operator %s" %
-                (type(clause).__name__, clause.operator))
+                "Cannot evaluate {0!s} with operator {1!s}".format(type(clause).__name__, clause.operator))
         return evaluate
 
     def visit_unary(self, clause):
@@ -127,8 +126,7 @@ class EvaluatorCompiler(object):
 
             return evaluate
         raise UnevaluatableError(
-            "Cannot evaluate %s with operator %s" %
-            (type(clause).__name__, clause.operator))
+            "Cannot evaluate {0!s} with operator {1!s}".format(type(clause).__name__, clause.operator))
 
     def visit_bindparam(self, clause):
         if clause.callable:

--- a/lib/sqlalchemy/orm/exc.py
+++ b/lib/sqlalchemy/orm/exc.py
@@ -164,4 +164,4 @@ def _default_unmapped(base, cls):
     name = _safe_cls_name(cls)
 
     if not mappers:
-        return "Class '%s' is not mapped" % name
+        return "Class '{0!s}' is not mapped".format(name)

--- a/lib/sqlalchemy/orm/instrumentation.py
+++ b/lib/sqlalchemy/orm/instrumentation.py
@@ -361,7 +361,7 @@ class ClassManager(dict):
     __nonzero__ = __bool__
 
     def __repr__(self):
-        return '<%s of %r at %x>' % (
+        return '<{0!s} of {1!r} at {2:x}>'.format(
             self.__class__.__name__, self.class_, id(self))
 
 

--- a/lib/sqlalchemy/orm/interfaces.py
+++ b/lib/sqlalchemy/orm/interfaces.py
@@ -241,7 +241,7 @@ class MapperProperty(_MappedAttribute, InspectionAttr, util.MemoizedSlots):
         """
 
     def __repr__(self):
-        return '<%s at 0x%x; %s>' % (
+        return '<{0!s} at 0x{1:x}; {2!s}>'.format(
             self.__class__.__name__,
             id(self), getattr(self, 'key', 'no key'))
 
@@ -342,7 +342,7 @@ class PropComparator(operators.ColumnOperators):
         self._adapt_to_entity = adapt_to_entity
 
     def __clause_element__(self):
-        raise NotImplementedError("%r" % self)
+        raise NotImplementedError("{0!r}".format(self))
 
     def _query_clause_element(self):
         return self.__clause_element__()
@@ -550,7 +550,7 @@ class StrategizedProperty(MapperProperty):
                     return strategies[key]
                 except KeyError:
                     pass
-        raise Exception("can't locate strategy for %s %s" % (cls, key))
+        raise Exception("can't locate strategy for {0!s} {1!s}".format(cls, key))
 
 
 class MapperOption(object):

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -583,8 +583,8 @@ def _decorate_polymorphic_switch(
             sub_mapper = mapper.polymorphic_map[discriminator]
         except KeyError:
             raise AssertionError(
-                "No such polymorphic_identity %r is defined" %
-                discriminator)
+                "No such polymorphic_identity {0!r} is defined".format(
+                discriminator))
         else:
             if sub_mapper is mapper:
                 return None

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -946,8 +946,7 @@ class Mapper(InspectionAttr):
                 self.inherits = class_mapper(self.inherits, configure=False)
             if not issubclass(self.class_, self.inherits.class_):
                 raise sa_exc.ArgumentError(
-                    "Class '%s' does not inherit from '%s'" %
-                    (self.class_.__name__, self.inherits.class_.__name__))
+                    "Class '{0!s}' does not inherit from '{1!s}'".format(self.class_.__name__, self.inherits.class_.__name__))
             if self.non_primary != self.inherits.non_primary:
                 np = not self.non_primary and "primary" or "non-primary"
                 raise sa_exc.ArgumentError(
@@ -1043,8 +1042,7 @@ class Mapper(InspectionAttr):
 
         if self.mapped_table is None:
             raise sa_exc.ArgumentError(
-                "Mapper '%s' does not have a mapped_table specified."
-                % self)
+                "Mapper '{0!s}' does not have a mapped_table specified.".format(self))
 
     def _set_with_polymorphic(self, with_polymorphic):
         if with_polymorphic == '*':
@@ -1682,8 +1680,7 @@ class Mapper(InspectionAttr):
         column = columns[0]
         if not expression._is_column(column):
             raise sa_exc.ArgumentError(
-                "%s=%r is not an instance of MapperProperty or Column"
-                % (key, prop))
+                "{0!s}={1!r} is not an instance of MapperProperty or Column".format(key, prop))
 
         prop = self._props.get(key, None)
 
@@ -1817,11 +1814,11 @@ class Mapper(InspectionAttr):
         )
 
     def __repr__(self):
-        return '<Mapper at 0x%x; %s>' % (
+        return '<Mapper at 0x{0:x}; {1!s}>'.format(
             id(self), self.class_.__name__)
 
     def __str__(self):
-        return "Mapper|%s|%s%s" % (
+        return "Mapper|{0!s}|{1!s}{2!s}".format(
             self.class_.__name__,
             self.local_table is not None and
             self.local_table.description or None,
@@ -1861,7 +1858,7 @@ class Mapper(InspectionAttr):
             return self._props[key]
         except KeyError:
             raise sa_exc.InvalidRequestError(
-                "Mapper '%s' has no property '%s'" % (self, key))
+                "Mapper '{0!s}' has no property '{1!s}'".format(self, key))
 
     def get_property_by_column(self, column):
         """Given a :class:`.Column` object, return the
@@ -1892,8 +1889,7 @@ class Mapper(InspectionAttr):
                 m = _class_to_mapper(m)
                 if not m.isa(self):
                     raise sa_exc.InvalidRequestError(
-                        "%r does not inherit from %r" %
-                        (m, self))
+                        "{0!r} does not inherit from {1!r}".format(m, self))
 
                 if selectable is None:
                     mappers.update(m.iterate_to_root())
@@ -2348,7 +2344,7 @@ class Mapper(InspectionAttr):
         if self.include_properties is not None and \
                         name not in self.include_properties and \
                 (column is None or column not in self.include_properties):
-            self._log("not including property %s" % (name))
+            self._log("not including property {0!s}".format((name)))
             return True
 
         if self.exclude_properties is not None and \
@@ -2357,7 +2353,7 @@ class Mapper(InspectionAttr):
                             (
                                     column is not None and column in self.exclude_properties)
                 ):
-            self._log("excluding property %s" % (name))
+            self._log("excluding property {0!s}".format((name)))
             return True
 
         return False
@@ -2983,5 +2979,4 @@ class _ColumnMapping(dict):
                 "conflicting property '%s':%r" % (
                     column.table.name, column.name, column.key, prop))
         raise orm_exc.UnmappedColumnError(
-            "No column %s is configured on mapper %s..." %
-            (column, self.mapper))
+            "No column {0!s} is configured on mapper {1!s}...".format(column, self.mapper))

--- a/lib/sqlalchemy/orm/path_registry.py
+++ b/lib/sqlalchemy/orm/path_registry.py
@@ -138,7 +138,7 @@ class PathRegistry(object):
         elif token.endswith(":" + _DEFAULT_TOKEN):
             return TokenRegistry(self.root, token)
         else:
-            raise exc.ArgumentError("invalid token: %s" % token)
+            raise exc.ArgumentError("invalid token: {0!s}".format(token))
 
     def __add__(self, other):
         return util.reduce(
@@ -146,7 +146,7 @@ class PathRegistry(object):
             other.path, self)
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.path,)
+        return "{0!s}({1!r})".format(self.__class__.__name__, self.path)
 
 
 class RootRegistry(PathRegistry):
@@ -226,7 +226,7 @@ class PropRegistry(PathRegistry):
         """
         return ("loader",
                 self.parent.token(
-                    "%s:%s" % (
+                    "{0!s}:{1!s}".format(
                         self.prop.strategy_wildcard_key, _WILDCARD_TOKEN)
                 ).path
                 )
@@ -235,7 +235,7 @@ class PropRegistry(PathRegistry):
     def _default_path_loader_key(self):
         return ("loader",
                 self.parent.token(
-                    "%s:%s" % (self.prop.strategy_wildcard_key,
+                    "{0!s}:{1!s}".format(self.prop.strategy_wildcard_key,
                                _DEFAULT_TOKEN)
                 ).path
                 )

--- a/lib/sqlalchemy/orm/persistence.py
+++ b/lib/sqlalchemy/orm/persistence.py
@@ -1277,7 +1277,7 @@ class BulkUpdate(BulkUD):
                 return attr.key
         else:
             raise sa_exc.InvalidRequestError(
-                "Invalid expression type: %r" % key)
+                "Invalid expression type: {0!r}".format(key))
 
     def _do_exec(self):
 

--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -146,7 +146,7 @@ class ColumnProperty(StrategizedProperty):
 
         if kwargs:
             raise TypeError(
-                "%s received unexpected keyword argument(s): %s" % (
+                "{0!s} received unexpected keyword argument(s): {1!s}".format(
                     self.__class__.__name__,
                     ', '.join(sorted(kwargs.keys()))))
 

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -840,7 +840,7 @@ class Query(object):
             raise sa_exc.InvalidRequestError(
                 "Incorrect number of values in identifier to formulate "
                 "primary key for query.get(); primary key columns are %s" %
-                ','.join("'%s'" % c for c in mapper.primary_key))
+                ','.join("'{0!s}'".format(c) for c in mapper.primary_key))
 
         key = mapper.identity_key_from_primary_key(ident)
 
@@ -1962,8 +1962,8 @@ class Query(object):
                                                  kwargs.pop('isouter', False), \
                                                  kwargs.pop('full', False)
         if kwargs:
-            raise TypeError("unknown arguments: %s" %
-                            ', '.join(sorted(kwargs)))
+            raise TypeError("unknown arguments: {0!s}".format(
+                            ', '.join(sorted(kwargs))))
         return self._join(props,
                           outerjoin=isouter, full=full,
                           create_aliases=aliased,
@@ -1980,8 +1980,8 @@ class Query(object):
                                         kwargs.pop('from_joinpoint', False), \
                                         kwargs.pop('full', False)
         if kwargs:
-            raise TypeError("unknown arguments: %s" %
-                            ', '.join(sorted(kwargs)))
+            raise TypeError("unknown arguments: {0!s}".format(
+                            ', '.join(sorted(kwargs))))
         return self._join(props,
                           outerjoin=True, full=full, create_aliases=aliased,
                           from_joinpoint=from_joinpoint)
@@ -2127,7 +2127,7 @@ class Query(object):
 
         if left is None:
             if self._entities:
-                problem = "Don't know how to join from %s" % self._entities[0]
+                problem = "Don't know how to join from {0!s}".format(self._entities[0])
             else:
                 problem = "No entities to join from"
 
@@ -2166,8 +2166,8 @@ class Query(object):
         if (overlap or not create_aliases) and \
                         l_info.selectable is r_info.selectable:
             raise sa_exc.InvalidRequestError(
-                "Can't join table/selectable '%s' to itself" %
-                l_info.selectable)
+                "Can't join table/selectable '{0!s}' to itself".format(
+                l_info.selectable))
 
         right, onclause = self._prepare_right_side(
             r_info, right, onclause,
@@ -2214,8 +2214,7 @@ class Query(object):
             if not right_selectable.is_derived_from(
                     right_mapper.mapped_table):
                 raise sa_exc.InvalidRequestError(
-                    "Selectable '%s' is not derived from '%s'" %
-                    (right_selectable.description,
+                    "Selectable '{0!s}' is not derived from '{1!s}'".format(right_selectable.description,
                      right_mapper.mapped_table.description))
 
             if isinstance(right_selectable, expression.SelectBase):
@@ -3443,7 +3442,7 @@ class LockmodeArg(ForUpdateArg):
             read = False
         else:
             raise sa_exc.ArgumentError(
-                "Unknown with_lockmode argument: %r" % mode)
+                "Unknown with_lockmode argument: {0!r}".format(mode))
 
         return LockmodeArg(read=read, nowait=nowait)
 

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1994,19 +1994,19 @@ class JoinCondition(object):
         log.info('%s setup secondary join %s', self.prop,
                  self.secondaryjoin)
         log.info('%s synchronize pairs [%s]', self.prop,
-                 ','.join('(%s => %s)' % (l, r) for (l, r) in
+                 ','.join('({0!s} => {1!s})'.format(l, r) for (l, r) in
                           self.synchronize_pairs))
         log.info('%s secondary synchronize pairs [%s]', self.prop,
-                 ','.join('(%s => %s)' % (l, r) for (l, r) in
+                 ','.join('({0!s} => {1!s})'.format(l, r) for (l, r) in
                           self.secondary_synchronize_pairs or []))
         log.info('%s local/remote pairs [%s]', self.prop,
-                 ','.join('(%s / %s)' % (l, r) for (l, r) in
+                 ','.join('({0!s} / {1!s})'.format(l, r) for (l, r) in
                           self.local_remote_pairs))
         log.info('%s remote columns [%s]', self.prop,
-                 ','.join('%s' % col for col in self.remote_columns)
+                 ','.join('{0!s}'.format(col) for col in self.remote_columns)
                  )
         log.info('%s local columns [%s]', self.prop,
-                 ','.join('%s' % col for col in self.local_columns)
+                 ','.join('{0!s}'.format(col) for col in self.local_columns)
                  )
         log.info('%s relationship direction %s', self.prop,
                  self.direction)
@@ -2696,7 +2696,7 @@ class JoinCondition(object):
                             self.prop,
                             from_, to_,
                             ", ".join(
-                                "'%s' (copies %s to %s)" % (pr, fr_, to_)
+                                "'{0!s}' (copies {1!s} to {2!s})".format(pr, fr_, to_)
                                 for (pr, fr_) in other_props)
                         )
                     )

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -244,8 +244,8 @@ class SessionTransaction(object):
                 break
             elif current._parent is None:
                 raise sa_exc.InvalidRequestError(
-                    "Transaction %s is not on the active transaction list" % (
-                        upto))
+                    "Transaction {0!s} is not on the active transaction list".format((
+                        upto)))
             else:
                 current = current._parent
 
@@ -1121,8 +1121,8 @@ class Session(_SessionClassMethods):
         except sa_exc.NoInspectionAvailable:
             if not isinstance(key, type):
                 raise exc.ArgumentError(
-                    "Not acceptable bind target: %s" %
-                    key)
+                    "Not acceptable bind target: {0!s}".format(
+                    key))
             else:
                 self.__binds[key] = bind
         else:
@@ -1134,8 +1134,8 @@ class Session(_SessionClassMethods):
                     self.__binds[selectable] = bind
             else:
                 raise exc.ArgumentError(
-                    "Not acceptable bind target: %s" %
-                    key)
+                    "Not acceptable bind target: {0!s}".format(
+                    key))
 
     def bind_mapper(self, mapper, bind):
         """Associate a :class:`.Mapper` with a "bind", e.g. a :class:`.Engine`
@@ -1252,13 +1252,13 @@ class Session(_SessionClassMethods):
 
         context = []
         if mapper is not None:
-            context.append('mapper %s' % mapper)
+            context.append('mapper {0!s}'.format(mapper))
         if clause is not None:
             context.append('SQL expression')
 
         raise sa_exc.UnboundExecutionError(
-            "Could not locate a bind configured on %s or this Session" % (
-                ', '.join(context)))
+            "Could not locate a bind configured on {0!s} or this Session".format((
+                ', '.join(context))))
 
     def query(self, *entities, **kwargs):
         """Return a new :class:`.Query` object corresponding to this
@@ -1358,8 +1358,8 @@ class Session(_SessionClassMethods):
                 lockmode=lockmode,
                 only_load_props=attribute_names) is None:
             raise sa_exc.InvalidRequestError(
-                "Could not refresh instance '%s'" %
-                instance_str(instance))
+                "Could not refresh instance '{0!s}'".format(
+                instance_str(instance)))
 
     def expire_all(self):
         """Expires all persistent instances within this Session.
@@ -1485,8 +1485,8 @@ class Session(_SessionClassMethods):
             raise exc.UnmappedInstanceError(instance)
         if state.session_id is not self.hash_key:
             raise sa_exc.InvalidRequestError(
-                "Instance %s is not present in this Session" %
-                state_str(state))
+                "Instance {0!s} is not present in this Session".format(
+                state_str(state)))
 
         cascaded = list(state.manager.mapper.cascade_iterator(
             'expunge', state))
@@ -1648,8 +1648,8 @@ class Session(_SessionClassMethods):
         if state.key is None:
             if head:
                 raise sa_exc.InvalidRequestError(
-                    "Instance '%s' is not persisted" %
-                    state_str(state))
+                    "Instance '{0!s}' is not persisted".format(
+                    state_str(state)))
             else:
                 return
 
@@ -1863,8 +1863,8 @@ class Session(_SessionClassMethods):
     def _validate_persistent(self, state):
         if not self.identity_map.contains_state(state):
             raise sa_exc.InvalidRequestError(
-                "Instance '%s' is not persistent within this Session" %
-                state_str(state))
+                "Instance '{0!s}' is not persistent within this Session".format(
+                state_str(state)))
 
     def _save_impl(self, state):
         if state.key is not None:
@@ -1883,8 +1883,8 @@ class Session(_SessionClassMethods):
     def _update_impl(self, state, revert_deletion=False):
         if state.key is None:
             raise sa_exc.InvalidRequestError(
-                "Instance '%s' is not persisted" %
-                state_str(state))
+                "Instance '{0!s}' is not persisted".format(
+                state_str(state)))
 
         if state._deleted:
             if revert_deletion:
@@ -2761,10 +2761,10 @@ class sessionmaker(_SessionClassMethods):
         self.kw.update(new_kw)
 
     def __repr__(self):
-        return "%s(class_=%r,%s)" % (
+        return "{0!s}(class_={1!r},{2!s})".format(
             self.__class__.__name__,
             self.class_.__name__,
-            ", ".join("%s=%r" % (k, v) for k, v in self.kw.items())
+            ", ".join("{0!s}={1!r}".format(k, v) for k, v in self.kw.items())
         )
 
 

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -250,7 +250,7 @@ class DeferredColumnLoader(LoaderStrategy):
                                         loadopt and
                                         self.group and
                                     loadopt.local_opts.get(
-                                            'undefer_group_%s' % self.group,
+                                            'undefer_group_{0!s}'.format(self.group),
                                             False)
                         )
                 or
@@ -382,7 +382,7 @@ class RaiseLoader(NoLoader):
             result, adapter, populators):
         def invoke_raise_load(state, passive):
             raise sa_exc.InvalidRequestError(
-                "'%s' is not available due to lazy='raise'" % self
+                "'{0!s}' is not available due to lazy='raise'".format(self)
             )
 
         set_lazy_callable = InstanceState._instance_level_callable_processor(

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -128,7 +128,7 @@ class Load(Generative, MapperOption):
                 if default_token:
                     self.propagate_to_loaders = False
                 if wildcard_key:
-                    attr = "%s:%s" % (wildcard_key, attr)
+                    attr = "{0!s}:{1!s}".format(wildcard_key, attr)
                 return path.token(attr)
 
             try:
@@ -183,7 +183,7 @@ class Load(Generative, MapperOption):
         return path
 
     def __str__(self):
-        return "Load(strategy=%r)" % (self.strategy,)
+        return "Load(strategy={0!r})".format(self.strategy)
 
     def _coerce_strat(self, strategy):
         if strategy is not None:
@@ -262,7 +262,7 @@ class Load(Generative, MapperOption):
 
                 if i == 0 and c_token.endswith(':' + _DEFAULT_TOKEN):
                     return to_chop
-                elif c_token != 'relationship:%s' % (_WILDCARD_TOKEN,) and \
+                elif c_token != 'relationship:{0!s}'.format(_WILDCARD_TOKEN) and \
                                 c_token != p_token.key:
                     return None
 
@@ -299,7 +299,7 @@ class _UnboundLoad(Load):
                         attr in (_WILDCARD_TOKEN, _DEFAULT_TOKEN):
             if attr == _DEFAULT_TOKEN:
                 self.propagate_to_loaders = False
-            attr = "%s:%s" % (wildcard_key, attr)
+            attr = "{0!s}:{1!s}".format(wildcard_key, attr)
 
         return path + (attr,)
 
@@ -365,8 +365,8 @@ class _UnboundLoad(Load):
             if isinstance(c_token, util.string_types):
                 if i == 0 and c_token.endswith(':' + _DEFAULT_TOKEN):
                     return to_chop
-                elif c_token != 'relationship:%s' % (
-                        _WILDCARD_TOKEN,) and c_token != p_prop.key:
+                elif c_token != 'relationship:{0!s}'.format(
+                        _WILDCARD_TOKEN) and c_token != p_prop.key:
                     return None
             elif isinstance(c_token, PropComparator):
                 if c_token.property is not p_prop:
@@ -509,7 +509,7 @@ class loader_option(object):
         self.name = name = fn.__name__
         self.fn = fn
         if hasattr(Load, name):
-            raise TypeError("Load class already has a %s method." % (name))
+            raise TypeError("Load class already has a {0!s} method.".format((name)))
         setattr(Load, name, fn)
 
         return self
@@ -518,28 +518,28 @@ class loader_option(object):
         self._unbound_fn = fn
         fn_doc = self.fn.__doc__
         self.fn.__doc__ = """Produce a new :class:`.Load` object with the
-:func:`.orm.%(name)s` option applied.
+:func:`.orm.{name!s}` option applied.
 
-See :func:`.orm.%(name)s` for usage examples.
+See :func:`.orm.{name!s}` for usage examples.
 
-""" % {"name": self.name}
+""".format(**{"name": self.name})
 
         fn.__doc__ = fn_doc
         return self
 
     def _add_unbound_all_fn(self, fn):
         self._unbound_all_fn = fn
-        fn.__doc__ = """Produce a standalone "all" option for :func:`.orm.%(name)s`.
+        fn.__doc__ = """Produce a standalone "all" option for :func:`.orm.{name!s}`.
 
 .. deprecated:: 0.9.0
 
     The "_all()" style is replaced by method chaining, e.g.::
 
         session.query(MyClass).options(
-            %(name)s("someattribute").%(name)s("anotherattribute")
+            {name!s}("someattribute").{name!s}("anotherattribute")
         )
 
-""" % {"name": self.name}
+""".format(**{"name": self.name})
         return self
 
 
@@ -1083,7 +1083,7 @@ def undefer_group(loadopt, name):
     return loadopt.set_column_strategy(
         "*",
         None,
-        {"undefer_group_%s" % name: True},
+        {"undefer_group_{0!s}".format(name): True},
         opts_only=True
     )
 

--- a/lib/sqlalchemy/orm/unitofwork.py
+++ b/lib/sqlalchemy/orm/unitofwork.py
@@ -478,7 +478,7 @@ class PostSortRec(object):
         self.execute(uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             ",".join(str(x) for x in self.__dict__.values())
         )
@@ -507,7 +507,7 @@ class ProcessAll(IterateMappersMixin, PostSortRec):
         return iter([])
 
     def __repr__(self):
-        return "%s(%s, delete=%s)" % (
+        return "{0!s}({1!s}, delete={2!s})".format(
             self.__class__.__name__,
             self.dependency_processor,
             self.delete
@@ -613,7 +613,7 @@ class ProcessState(PostSortRec):
             dependency_processor.process_saves(uow, states)
 
     def __repr__(self):
-        return "%s(%s, %s, delete=%s)" % (
+        return "{0!s}({1!s}, {2!s}, delete={3!s})".format(
             self.__class__.__name__,
             self.dependency_processor,
             orm_util.state_str(self.state),
@@ -639,7 +639,7 @@ class SaveUpdateState(PostSortRec):
                              uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             orm_util.state_str(self.state)
         )
@@ -663,7 +663,7 @@ class DeleteState(PostSortRec):
                                uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             orm_util.state_str(self.state)
         )

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -40,9 +40,9 @@ class CascadeOptions(frozenset):
         values = set(value_list)
         if values.difference(cls._allowed_cascades):
             raise sa_exc.ArgumentError(
-                "Invalid cascade option(s): %s" %
+                "Invalid cascade option(s): {0!s}".format(
                 ", ".join([repr(x) for x in
-                           sorted(values.difference(cls._allowed_cascades))]))
+                           sorted(values.difference(cls._allowed_cascades))])))
 
         if "all" in values:
             values.update(cls._add_w_all_cascades)
@@ -64,9 +64,9 @@ class CascadeOptions(frozenset):
         return self
 
     def __repr__(self):
-        return "CascadeOptions(%r)" % (
+        return "CascadeOptions({0!r})".format((
             ",".join([x for x in sorted(self)])
-        )
+        ))
 
     @classmethod
     def from_string(cls, arg):
@@ -262,16 +262,14 @@ first()
                 "expected up to three positional arguments, "
                 "got %s" % len(args))
         if kwargs:
-            raise sa_exc.ArgumentError("unknown keyword arguments: %s"
-                                       % ", ".join(kwargs))
+            raise sa_exc.ArgumentError("unknown keyword arguments: {0!s}".format(", ".join(kwargs)))
         mapper = class_mapper(class_)
         if "ident" in locals():
             return mapper.identity_key_from_primary_key(util.to_list(ident))
         return mapper.identity_key_from_row(row)
     instance = kwargs.pop("instance")
     if kwargs:
-        raise sa_exc.ArgumentError("unknown keyword arguments: %s"
-                                   % ", ".join(kwargs.keys))
+        raise sa_exc.ArgumentError("unknown keyword arguments: {0!s}".format(", ".join(kwargs.keys)))
     mapper = object_mapper(instance)
     return mapper.identity_key_from_instance(instance)
 
@@ -379,7 +377,7 @@ class AliasedClass(object):
             adapt_on_names
         )
 
-        self.__name__ = 'AliasedClass_%s' % mapper.class_.__name__
+        self.__name__ = 'AliasedClass_{0!s}'.format(mapper.class_.__name__)
 
     def __getattr__(self, key):
         try:
@@ -417,7 +415,7 @@ class AliasedClass(object):
             return attr
 
     def __repr__(self):
-        return '<AliasedClass at 0x%x; %s>' % (
+        return '<AliasedClass at 0x{0:x}; {1!s}>'.format(
             id(self), self._aliased_insp._target.__name__)
 
 
@@ -545,16 +543,16 @@ class AliasedInsp(InspectionAttr):
         elif mapper.isa(self.mapper):
             return self
         else:
-            assert False, "mapper %s doesn't correspond to %s" % (
+            assert False, "mapper {0!s} doesn't correspond to {1!s}".format(
                 mapper, self)
 
     def __repr__(self):
         if self.with_polymorphic_mappers:
-            with_poly = "(%s)" % ", ".join(
-                mp.class_.__name__ for mp in self.with_polymorphic_mappers)
+            with_poly = "({0!s})".format(", ".join(
+                mp.class_.__name__ for mp in self.with_polymorphic_mappers))
         else:
             with_poly = ""
-        return '<AliasedInsp at 0x%x; %s%s>' % (
+        return '<AliasedInsp at 0x{0:x}; {1!s}{2!s}>'.format(
             id(self), self.class_.__name__, with_poly)
 
 

--- a/lib/sqlalchemy/pool.py
+++ b/lib/sqlalchemy/pool.py
@@ -230,8 +230,7 @@ class Pool(log.Identified):
             self._reset_on_return = reset_commit
         else:
             raise exc.ArgumentError(
-                "Invalid value for 'reset_on_return': %r"
-                % reset_on_return)
+                "Invalid value for 'reset_on_return': {0!r}".format(reset_on_return))
 
         self.echo = echo
 
@@ -956,8 +955,7 @@ class SingletonThreadPool(Pool):
             c.close()
 
     def status(self):
-        return "SingletonThreadPool id:%d size: %d" % \
-               (id(self), len(self._all_conns))
+        return "SingletonThreadPool id:{0:d} size: {1:d}".format(id(self), len(self._all_conns))
 
     def _do_return_conn(self, conn):
         pass
@@ -1262,8 +1260,8 @@ class AssertionPool(Pool):
     def _do_get(self):
         if self._checked_out:
             if self._checkout_traceback:
-                suffix = ' at:\n%s' % ''.join(
-                    chop_traceback(self._checkout_traceback))
+                suffix = ' at:\n{0!s}'.format(''.join(
+                    chop_traceback(self._checkout_traceback)))
             else:
                 suffix = ''
             raise AssertionError("connection is already checked out" + suffix)

--- a/lib/sqlalchemy/processors.py
+++ b/lib/sqlalchemy/processors.py
@@ -90,7 +90,7 @@ def py_fallback():
         return process
 
     def to_decimal_processor_factory(target_class, scale):
-        fstring = "%%.%df" % scale
+        fstring = "%.{0:d}f".format(scale)
 
         def process(value):
             if value is None:
@@ -158,7 +158,7 @@ try:
         # For example, the Python implementation might return
         # Decimal('5.00000') whereas the C implementation will
         # return Decimal('5'). These are equivalent of course.
-        return DecimalResultProcessor(target_class, "%%.%df" % scale).process
+        return DecimalResultProcessor(target_class, "%.{0:d}f".format(scale)).process
 
 except ImportError:
     globals().update(py_fallback())

--- a/lib/sqlalchemy/sql/annotation.py
+++ b/lib/sqlalchemy/sql/annotation.py
@@ -182,9 +182,9 @@ def _new_annotation_type(cls, base_cls):
             break
 
     annotated_classes[cls] = anno_cls = type(
-        "Annotated%s" % cls.__name__,
+        "Annotated{0!s}".format(cls.__name__),
         (base_cls, cls), {})
-    globals()["Annotated%s" % cls.__name__] = anno_cls
+    globals()["Annotated{0!s}".format(cls.__name__)] = anno_cls
     return anno_cls
 
 

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -91,7 +91,7 @@ class _DialectArgView(collections.MutableMapping):
 
     def __iter__(self):
         return (
-            util.safe_kwarg("%s_%s" % (dialect_name, value_name))
+            util.safe_kwarg("{0!s}_{1!s}".format(dialect_name, value_name))
             for dialect_name in self.obj.dialect_options
             for value_name in
             self.obj.dialect_options[dialect_name]._non_defaults
@@ -624,9 +624,9 @@ def _bind_or_error(schemaitem, msg=None):
         label = getattr(schemaitem, 'fullname',
                         getattr(schemaitem, 'name', None))
         if label:
-            item = '%s object %r' % (name, label)
+            item = '{0!s} object {1!r}'.format(name, label)
         else:
-            item = '%s object' % name
+            item = '{0!s} object'.format(name)
         if msg is None:
             msg = "%s is not bound to an Engine or Connection.  " \
                   "Execution can not proceed without a database to execute " \

--- a/lib/sqlalchemy/sql/crud.py
+++ b/lib/sqlalchemy/sql/crud.py
@@ -142,8 +142,8 @@ def _get_crud_params(compiler, stmt, **kw):
         ).difference(check_columns)
         if check:
             raise exc.CompileError(
-                "Unconsumed column names: %s" %
-                (", ".join("%s" % c for c in check))
+                "Unconsumed column names: {0!s}".format(
+                (", ".join("{0!s}".format(c) for c in check)))
             )
 
     if stmt._has_multi_parameters:
@@ -190,7 +190,7 @@ def _key_getters_for_crud_column(compiler, stmt):
 
         def _col_bind_name(col):
             if col.table in _et:
-                return "%s_%s" % (col.table.name, col.key)
+                return "{0!s}_{1!s}".format(col.table.name, col.key)
             else:
                 return col.key
 
@@ -315,7 +315,7 @@ def _append_param_parameter(
             compiler, c, value, required=value is REQUIRED,
             name=_col_bind_name(c)
             if not stmt._has_multi_parameters
-            else "%s_0" % _col_bind_name(c),
+            else "{0!s}_0".format(_col_bind_name(c)),
             **kw
         )
     else:
@@ -394,7 +394,7 @@ def _create_update_prefetch_bind_param(compiler, c, process=True, name=None):
 
 class _multiparam_column(elements.ColumnElement):
     def __init__(self, original, index):
-        self.key = "%s_%d" % (original.key, index + 1)
+        self.key = "{0!s}_{1:d}".format(original.key, index + 1)
         self.original = original
         self.default = original.default
         self.type = original.type
@@ -596,7 +596,7 @@ def _extend_values_for_multiparams(compiler, stmt, values, kw):
                 c,
                 (_create_bind_param(
                     compiler, c, row[c.key],
-                    name="%s_%d" % (c.key, i + 1)
+                    name="{0!s}_{1:d}".format(c.key, i + 1)
                 ) if elements._is_literal(row[c.key])
                  else compiler.process(
                     row[c.key].self_group(), **kw))

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -376,8 +376,8 @@ class DDL(DDLElement):
 
         if not isinstance(statement, util.string_types):
             raise exc.ArgumentError(
-                "Expected a string or unicode SQL statement, got '%r'" %
-                statement)
+                "Expected a string or unicode SQL statement, got '{0!r}'".format(
+                statement))
 
         self.statement = statement
         self.context = context or {}
@@ -387,10 +387,10 @@ class DDL(DDLElement):
         self._bind = bind
 
     def __repr__(self):
-        return '<%s@%s; %s>' % (
+        return '<{0!s}@{1!s}; {2!s}>'.format(
             type(self).__name__, id(self),
             ', '.join([repr(self.statement)] +
-                      ['%s=%r' % (key, getattr(self, key))
+                      ['{0!s}={1!r}'.format(key, getattr(self, key))
                        for key in ('on', 'context')
                        if getattr(self, key)]))
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -486,7 +486,7 @@ class ClauseElement(Visitable):
         if friendly is None:
             return object.__repr__(self)
         else:
-            return '<%s.%s at 0x%x; %s>' % (
+            return '<{0!s}.{1!s} at 0x{2:x}; {3!s}>'.format(
                 self.__module__, self.__class__.__name__, id(self), friendly)
 
 
@@ -675,7 +675,7 @@ class ColumnElement(operators.ColumnOperators, ClauseElement):
             return getattr(self.comparator, key)
         except AttributeError:
             raise AttributeError(
-                'Neither %r object nor %r object has an attribute %r' % (
+                'Neither {0!r} object nor {1!r} object has an attribute {2!r}'.format(
                     type(self).__name__,
                     type(self.comparator).__name__,
                     key)
@@ -829,7 +829,7 @@ class ColumnElement(operators.ColumnOperators, ClauseElement):
             self = self._is_clone_of
 
         return _anonymous_label(
-            '%%(%d %s)s' % (id(self), getattr(self, 'name', 'anon'))
+            '%({0:d} {1!s})s'.format(id(self), getattr(self, 'name', 'anon'))
         )
 
 
@@ -1066,11 +1066,10 @@ class BindParameter(ColumnElement):
             key = quoted_name(key, quote)
 
         if unique:
-            self.key = _anonymous_label('%%(%d %s)s' % (id(self), key
+            self.key = _anonymous_label('%({0:d} {1!s})s'.format(id(self), key
                                                         or 'param'))
         else:
-            self.key = key or _anonymous_label('%%(%d param)s'
-                                               % id(self))
+            self.key = key or _anonymous_label('%({0:d} param)s'.format(id(self)))
 
         # identifying key that won't change across
         # clones, used to identify the bind's logical
@@ -1128,7 +1127,7 @@ class BindParameter(ColumnElement):
     def _clone(self):
         c = ClauseElement._clone(self)
         if self.unique:
-            c.key = _anonymous_label('%%(%d %s)s' % (id(c), c._orig_key
+            c.key = _anonymous_label('%({0:d} {1!s})s'.format(id(c), c._orig_key
                                                      or 'param'))
         return c
 
@@ -1136,7 +1135,7 @@ class BindParameter(ColumnElement):
         if not self.unique:
             self.unique = True
             self.key = _anonymous_label(
-                '%%(%d %s)s' % (id(self), self._orig_key or 'param'))
+                '%({0:d} {1!s})s'.format(id(self), self._orig_key or 'param'))
 
     def compare(self, other, **kw):
         """Compare this :class:`BindParameter` to the given
@@ -1158,7 +1157,7 @@ class BindParameter(ColumnElement):
         return d
 
     def __repr__(self):
-        return 'BindParameter(%r, %r, type_=%r)' % (self.key,
+        return 'BindParameter({0!r}, {1!r}, type_={2!r})'.format(self.key,
                                                     self.value, self.type)
 
 
@@ -1229,7 +1228,7 @@ class TextClause(Executable, ClauseElement):
 
         def repl(m):
             self._bindparams[m.group(1)] = BindParameter(m.group(1))
-            return ':%s' % m.group(1)
+            return ':{0!s}'.format(m.group(1))
 
         # scan the string and search for bind parameter names, add them
         # to the list of bindparams
@@ -3520,7 +3519,7 @@ class Label(ColumnElement):
             self._resolve_label = self.name
         else:
             self.name = _anonymous_label(
-                '%%(%d %s)s' % (id(self), getattr(element, 'name', 'anon'))
+                '%({0:d} {1!s})s'.format(id(self), getattr(element, 'name', 'anon'))
             )
 
         self.key = self._label = self._key_label = self.name
@@ -3575,7 +3574,7 @@ class Label(ColumnElement):
         self.__dict__.pop('_allow_label_resolve', None)
         if anonymize_labels:
             self.name = self._resolve_label = _anonymous_label(
-                '%%(%d %s)s' % (
+                '%({0:d} {1!s})s'.format(
                     id(self), getattr(self.element, 'name', 'anon'))
             )
             self.key = self._label = self._key_label = self.name
@@ -3949,7 +3948,7 @@ class quoted_name(util.MemoizedSlots, util.text_type):
         backslashed = self.encode('ascii', 'backslashreplace')
         if not util.py2k:
             backslashed = backslashed.decode('ascii')
-        return "'%s'" % backslashed
+        return "'{0!s}'".format(backslashed)
 
 
 class _truncated_label(quoted_name):
@@ -4100,7 +4099,7 @@ def _string_or_unprintable(element):
         try:
             return str(element)
         except Exception:
-            return "unprintable element %r" % element
+            return "unprintable element {0!r}".format(element)
 
 
 def _expand_cloned(elements):

--- a/lib/sqlalchemy/sql/naming.py
+++ b/lib/sqlalchemy/sql/naming.py
@@ -74,8 +74,8 @@ class ConventionDict(object):
     def __getitem__(self, key):
         if key in self.convention:
             return self.convention[key](self.const, self.table)
-        elif hasattr(self, '_key_%s' % key):
-            return getattr(self, '_key_%s' % key)()
+        elif hasattr(self, '_key_{0!s}'.format(key)):
+            return getattr(self, '_key_{0!s}'.format(key))()
         else:
             col_template = re.match(r".*_?column_(\d+)_.+", key)
             if col_template:

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -423,7 +423,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         else:
             if mustexist:
                 raise exc.InvalidRequestError(
-                    "Table '%s' not defined" % (key))
+                    "Table '{0!s}' not defined".format((key)))
             table = object.__new__(cls)
             table.dispatch.before_parent_attach(table, metadata)
             metadata._add_table(name, schema, table)
@@ -477,7 +477,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         self.foreign_keys = set()
         self._extra_dependencies = set()
         if self.schema is not None:
-            self.fullname = "%s.%s" % (self.schema, self.name)
+            self.fullname = "{0!s}.{1!s}".format(self.schema, self.name)
         else:
             self.fullname = self.name
 
@@ -616,10 +616,10 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         return _get_table_key(self.name, self.schema)
 
     def __repr__(self):
-        return "Table(%s)" % ', '.join(
+        return "Table({0!s})".format(', '.join(
             [repr(self.name)] + [repr(self.metadata)] +
             [repr(x) for x in self.columns] +
-            ["%s=%s" % (k, repr(getattr(self, k))) for k in ['schema']])
+            ["{0!s}={1!s}".format(k, repr(getattr(self, k))) for k in ['schema']]))
 
     def __str__(self):
         return _get_table_key(self.description, self.schema)
@@ -1270,13 +1270,13 @@ class Column(SchemaItem, ColumnClause):
             kwarg.append('default')
         if self.server_default:
             kwarg.append('server_default')
-        return "Column(%s)" % ', '.join(
+        return "Column({0!s})".format(', '.join(
             [repr(self.name)] + [repr(self.type)] +
             [repr(x) for x in self.foreign_keys if x is not None] +
             [repr(x) for x in self.constraints] +
-            [(self.table is not None and "table=<%s>" %
-              self.table.description or "table=None")] +
-            ["%s=%s" % (k, repr(getattr(self, k))) for k in kwarg])
+            [(self.table is not None and "table=<{0!s}>".format(
+              self.table.description) or "table=None")] +
+            ["{0!s}={1!s}".format(k, repr(getattr(self, k))) for k in kwarg]))
 
     def _set_parent(self, table):
         if not self.name:
@@ -1289,7 +1289,7 @@ class Column(SchemaItem, ColumnClause):
         existing = getattr(self, 'table', None)
         if existing is not None and existing is not table:
             raise exc.ArgumentError(
-                "Column object '%s' already assigned to Table '%s'" % (
+                "Column object '{0!s}' already assigned to Table '{1!s}'".format(
                     self.key,
                     existing.description
                 ))
@@ -1599,7 +1599,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         self._unvalidated_dialect_kw = dialect_kw
 
     def __repr__(self):
-        return "ForeignKey(%r)" % self._get_colspec()
+        return "ForeignKey({0!r})".format(self._get_colspec())
 
     def copy(self, schema=None):
         """Produce a copy of this :class:`.ForeignKey` object.
@@ -1643,15 +1643,15 @@ class ForeignKey(DialectKWArgs, SchemaItem):
             _schema, tname, colname = self._column_tokens
             if table_name is not None:
                 tname = table_name
-            return "%s.%s.%s" % (schema, tname, colname)
+            return "{0!s}.{1!s}.{2!s}".format(schema, tname, colname)
         elif table_name:
             schema, tname, colname = self._column_tokens
             if schema:
-                return "%s.%s.%s" % (schema, table_name, colname)
+                return "{0!s}.{1!s}.{2!s}".format(schema, table_name, colname)
             else:
-                return "%s.%s" % (table_name, colname)
+                return "{0!s}.{1!s}".format(table_name, colname)
         elif self._table_column is not None:
-            return "%s.%s" % (
+            return "{0!s}.{1!s}".format(
                 self._table_column.table.fullname, self._table_column.key)
         else:
             return self._colspec
@@ -1696,8 +1696,8 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         m = self._get_colspec().split('.')
         if m is None:
             raise exc.ArgumentError(
-                "Invalid foreign key column specification: %s" %
-                self._colspec)
+                "Invalid foreign key column specification: {0!s}".format(
+                self._colspec))
         if (len(m) == 1):
             tname = m.pop()
             colname = None
@@ -2055,7 +2055,7 @@ class ColumnDefault(DefaultGenerator):
     __visit_name__ = property(_visit_name)
 
     def __repr__(self):
-        return "ColumnDefault(%r)" % self.arg
+        return "ColumnDefault({0!r})".format(self.arg)
 
 
 class Sequence(DefaultGenerator):
@@ -2367,8 +2367,7 @@ class DefaultClause(FetchedValue):
         self.reflected = _reflected
 
     def __repr__(self):
-        return "DefaultClause(%r, for_update=%r)" % \
-               (self.arg, self.for_update)
+        return "DefaultClause({0!r}, for_update={1!r})".format(self.arg, self.for_update)
 
 
 class PassiveDefault(DefaultClause):
@@ -2566,8 +2565,7 @@ class ColumnCollectionMixin(object):
             others = [c for c in columns[1:] if c.table is not table]
             if others:
                 raise exc.ArgumentError(
-                    "Column(s) %s are not part of table '%s'." %
-                    (", ".join("'%s'" % c for c in others),
+                    "Column(s) {0!s} are not part of table '{1!s}'.".format(", ".join("'{0!s}'".format(c) for c in others),
                      table.description)
                 )
 
@@ -3057,9 +3055,9 @@ class PrimaryKeyConstraint(ColumnCollectionConstraint):
                 "may become an exception in a future release" %
                 (
                     table.name,
-                    ", ".join("'%s'" % c.name for c in table_pks),
-                    ", ".join("'%s'" % c.name for c in self.columns),
-                    ", ".join("'%s'" % c.name for c in self.columns)
+                    ", ".join("'{0!s}'".format(c.name) for c in table_pks),
+                    ", ".join("'{0!s}'".format(c.name) for c in self.columns),
+                    ", ".join("'{0!s}'".format(c.name) for c in self.columns)
                 )
             )
             table_pks[:] = []
@@ -3368,12 +3366,12 @@ class Index(DialectKWArgs, ColumnCollectionMixin, SchemaItem):
         bind._run_visitor(ddl.SchemaDropper, self)
 
     def __repr__(self):
-        return 'Index(%s)' % (
+        return 'Index({0!s})'.format((
             ", ".join(
                 [repr(self.name)] +
                 [repr(e) for e in self.expressions] +
                 (self.unique and ["unique=True"] or [])
-            ))
+            )))
 
 
 DEFAULT_NAMING_CONVENTION = util.immutabledict({
@@ -3555,7 +3553,7 @@ class MetaData(SchemaItem):
     """
 
     def __repr__(self):
-        return 'MetaData(bind=%r)' % self.bind
+        return 'MetaData(bind={0!r})'.format(self.bind)
 
     def __contains__(self, table_or_key):
         if not isinstance(table_or_key, util.string_types):
@@ -3770,7 +3768,7 @@ class MetaData(SchemaItem):
                 )
 
             if schema is not None:
-                available_w_schema = util.OrderedSet(["%s.%s" % (schema, name)
+                available_w_schema = util.OrderedSet(["{0!s}.{1!s}".format(schema, name)
                                                       for name in available])
             else:
                 available_w_schema = available
@@ -3789,7 +3787,7 @@ class MetaData(SchemaItem):
             else:
                 missing = [name for name in only if name not in available]
                 if missing:
-                    s = schema and (" schema '%s'" % schema) or ''
+                    s = schema and (" schema '{0!s}'".format(schema)) or ''
                     raise exc.InvalidRequestError(
                         'Could not reflect: requested table(s) not available '
                         'in %s%s: (%s)' %
@@ -3961,7 +3959,7 @@ class _SchemaTranslateMap(object):
 
             self.__call__ = schema_for_object
             self.hash_key = ";".join(
-                "%s=%s" % (k, map_[k])
+                "{0!s}={1!s}".format(k, map_[k])
                 for k in sorted(map_, key=str)
             )
             self.is_default = False

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -267,8 +267,8 @@ class HasPrefixes(object):
         """
         dialect = kw.pop('dialect', None)
         if kw:
-            raise exc.ArgumentError("Unsupported argument(s): %s" %
-                                    ",".join(kw))
+            raise exc.ArgumentError("Unsupported argument(s): {0!s}".format(
+                                    ",".join(kw)))
         self._setup_prefixes(expr, dialect)
 
     def _setup_prefixes(self, prefixes, dialect=None):
@@ -303,8 +303,8 @@ class HasSuffixes(object):
         """
         dialect = kw.pop('dialect', None)
         if kw:
-            raise exc.ArgumentError("Unsupported argument(s): %s" %
-                                    ",".join(kw))
+            raise exc.ArgumentError("Unsupported argument(s): {0!s}".format(
+                                    ",".join(kw)))
         self._setup_suffixes(expr, dialect)
 
     def _setup_suffixes(self, suffixes, dialect=None):
@@ -873,7 +873,7 @@ class Join(FromClause):
 
     @property
     def description(self):
-        return "Join object on %s(%d) and %s(%d)" % (
+        return "Join object on {0!s}({1:d}) and {2!s}({3:d})".format(
             self.left.description,
             id(self.left),
             self.right.description,
@@ -1234,7 +1234,7 @@ class Alias(FromClause):
         if name is None:
             if self.original.named_with_column:
                 name = getattr(self.original, 'name', None)
-            name = _anonymous_label('%%(%d %s)s' % (id(self), name
+            name = _anonymous_label('%({0:d} {1!s})s'.format(id(self), name
                                                     or 'anon'))
         self.name = name
 
@@ -1823,7 +1823,7 @@ class ForUpdateArg(ClauseElement):
         elif arg == 'read_nowait':
             read = nowait = True
         elif arg is not True:
-            raise exc.ArgumentError("Unknown for_update argument: %r" % arg)
+            raise exc.ArgumentError("Unknown for_update argument: {0!r}".format(arg))
 
         return ForUpdateArg(read=read, nowait=nowait)
 

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -200,7 +200,7 @@ class String(Concatenable, TypeEngine):
     def literal_processor(self, dialect):
         def process(value):
             value = value.replace("'", "''")
-            return "'%s'" % value
+            return "'{0!s}'".format(value)
 
         return process
 
@@ -837,7 +837,7 @@ class _Binary(TypeEngine):
     def literal_processor(self, dialect):
         def process(value):
             value = value.decode(dialect.encoding).replace("'", "''")
-            return "'%s'" % value
+            return "'{0!s}'".format(value)
 
         return process
 
@@ -1271,14 +1271,14 @@ class Enum(String, SchemaType):
                 return elem
             else:
                 raise LookupError(
-                    '"%s" is not among the defined enum values' % elem)
+                    '"{0!s}" is not among the defined enum values'.format(elem))
 
     def _object_value_for_elem(self, elem):
         try:
             return self._object_lookup[elem]
         except KeyError:
             raise LookupError(
-                '"%s" is not among the defined enum values' % elem)
+                '"{0!s}" is not among the defined enum values'.format(elem))
 
     def __repr__(self):
         return util.generic_repr(self,
@@ -2404,7 +2404,7 @@ def _resolve_value_to_type(value):
                         insp.__class__ in inspection._registrars
         ):
             raise exc.ArgumentError(
-                "Object %r is not legal as a SQL literal value" % value)
+                "Object {0!r} is not legal as a SQL literal value".format(value))
         return NULLTYPE
     else:
         return _result_type

--- a/lib/sqlalchemy/sql/util.py
+++ b/lib/sqlalchemy/sql/util.py
@@ -286,7 +286,7 @@ def bind_values(clause):
 def _quote_ddl_expr(element):
     if isinstance(element, util.string_types):
         element = element.replace("'", "''")
-        return "'%s'" % element
+        return "'{0!s}'".format(element)
     else:
         return repr(element)
 
@@ -305,8 +305,7 @@ class _repr_base(object):
             segment_length = self.max_chars // 2
             rep = (
                 rep[0:segment_length] +
-                (" ... (%d characters truncated) ... "
-                 % (lenrep - self.max_chars)) +
+                (" ... ({0:d} characters truncated) ... ".format((lenrep - self.max_chars))) +
                 rep[-segment_length:]
             )
         return rep
@@ -323,7 +322,7 @@ class _repr_row(_repr_base):
 
     def __repr__(self):
         trunc = self.trunc
-        return "(%s%s)" % (
+        return "({0!s}{1!s})".format(
             ", ".join(trunc(value) for value in self.row),
             "," if len(self.row) == 1 else ""
         )
@@ -381,7 +380,7 @@ class _repr_params(_repr_base):
                 elem_type = self._DICT
             else:
                 assert False, \
-                    "Unknown parameter type %s" % (type(multi_params[0]))
+                    "Unknown parameter type {0!s}".format((type(multi_params[0])))
 
             elements = ", ".join(
                 self._repr_params(params, elem_type)
@@ -390,29 +389,29 @@ class _repr_params(_repr_base):
             elements = ""
 
         if typ == self._LIST:
-            return "[%s]" % elements
+            return "[{0!s}]".format(elements)
         else:
-            return "(%s)" % elements
+            return "({0!s})".format(elements)
 
     def _repr_params(self, params, typ):
         trunc = self.trunc
         if typ is self._DICT:
-            return "{%s}" % (
+            return "{{{0!s}}}".format((
                 ", ".join(
-                    "%r: %s" % (key, trunc(value))
+                    "{0!r}: {1!s}".format(key, trunc(value))
                     for key, value in params.items()
                 )
-            )
+            ))
         elif typ is self._TUPLE:
-            return "(%s%s)" % (
+            return "({0!s}{1!s})".format(
                 ", ".join(trunc(value) for value in params),
                 "," if len(params) == 1 else ""
 
             )
         else:
-            return "[%s]" % (
+            return "[{0!s}]".format((
                 ", ".join(trunc(value) for value in params)
-            )
+            ))
 
 
 def adapt_criterion_to_null(crit, nulls):

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -70,7 +70,7 @@ def _generate_dispatch(cls):
             # There is an optimization opportunity here because the
             # the string name of the class's __visit_name__ is known at
             # this early stage (import time) so it can be pre-constructed.
-            getter = operator.attrgetter("visit_%s" % visit_name)
+            getter = operator.attrgetter("visit_{0!s}".format(visit_name))
 
             def _compiler_dispatch(self, visitor, **kw):
                 try:
@@ -84,7 +84,7 @@ def _generate_dispatch(cls):
             # __visit_name__ is not yet a string. As a result, the visit
             # string has to be recalculated with each compilation.
             def _compiler_dispatch(self, visitor, **kw):
-                visit_attr = 'visit_%s' % self.__visit_name__
+                visit_attr = 'visit_{0!s}'.format(self.__visit_name__)
                 try:
                     meth = getattr(visitor, visit_attr)
                 except AttributeError:
@@ -116,7 +116,7 @@ class ClauseVisitor(object):
 
     def traverse_single(self, obj, **kw):
         for v in self._visitor_iterator:
-            meth = getattr(v, "visit_%s" % obj.__visit_name__, None)
+            meth = getattr(v, "visit_{0!s}".format(obj.__visit_name__), None)
             if meth:
                 return meth(obj, **kw)
 

--- a/lib/sqlalchemy/testing/assertions.py
+++ b/lib/sqlalchemy/testing/assertions.py
@@ -149,9 +149,9 @@ def _expect_warnings(exc_cls, messages, regex=True, assert_=True):
         yield
 
     if assert_:
-        assert not seen, "Warnings were not seen: %s" % \
+        assert not seen, "Warnings were not seen: {0!s}".format( \
                          ", ".join(
-                             "%r" % (s.pattern if regex else s) for s in seen)
+                             "{0!r}".format((s.pattern if regex else s)) for s in seen))
 
 
 def global_cleanup_assertions():
@@ -181,8 +181,7 @@ def _assert_no_stray_pool_connections():
         # OK, let's be somewhat forgiving.
         _STRAY_CONNECTION_FAILURES += 1
 
-        print("Encountered a stray connection in test cleanup: %s"
-              % str(pool._refs))
+        print("Encountered a stray connection in test cleanup: {0!s}".format(str(pool._refs)))
         # then do a real GC sweep.   We shouldn't even be here
         # so a single sweep should really be doing it, otherwise
         # there's probably a real unreachable cycle somewhere.
@@ -208,22 +207,22 @@ def _assert_no_stray_pool_connections():
 
 
 def eq_regex(a, b, msg=None):
-    assert re.match(b, a), msg or "%r !~ %r" % (a, b)
+    assert re.match(b, a), msg or "{0!r} !~ {1!r}".format(a, b)
 
 
 def eq_(a, b, msg=None):
     """Assert a == b, with repr messaging on failure."""
-    assert a == b, msg or "%r != %r" % (a, b)
+    assert a == b, msg or "{0!r} != {1!r}".format(a, b)
 
 
 def ne_(a, b, msg=None):
     """Assert a != b, with repr messaging on failure."""
-    assert a != b, msg or "%r == %r" % (a, b)
+    assert a != b, msg or "{0!r} == {1!r}".format(a, b)
 
 
 def le_(a, b, msg=None):
     """Assert a <= b, with repr messaging on failure."""
-    assert a <= b, msg or "%r != %r" % (a, b)
+    assert a <= b, msg or "{0!r} != {1!r}".format(a, b)
 
 
 def is_true(a, msg=None):
@@ -236,27 +235,27 @@ def is_false(a, msg=None):
 
 def is_(a, b, msg=None):
     """Assert a is b, with repr messaging on failure."""
-    assert a is b, msg or "%r is not %r" % (a, b)
+    assert a is b, msg or "{0!r} is not {1!r}".format(a, b)
 
 
 def is_not_(a, b, msg=None):
     """Assert a is not b, with repr messaging on failure."""
-    assert a is not b, msg or "%r is %r" % (a, b)
+    assert a is not b, msg or "{0!r} is {1!r}".format(a, b)
 
 
 def in_(a, b, msg=None):
     """Assert a in b, with repr messaging on failure."""
-    assert a in b, msg or "%r not in %r" % (a, b)
+    assert a in b, msg or "{0!r} not in {1!r}".format(a, b)
 
 
 def not_in_(a, b, msg=None):
     """Assert a in not b, with repr messaging on failure."""
-    assert a not in b, msg or "%r is in %r" % (a, b)
+    assert a not in b, msg or "{0!r} is in {1!r}".format(a, b)
 
 
 def startswith_(a, fragment, msg=None):
     """Assert a.startswith(fragment), with repr messaging on failure."""
-    assert a.startswith(fragment), msg or "%r does not start with %r" % (
+    assert a.startswith(fragment), msg or "{0!r} does not start with {1!r}".format(
         a, fragment)
 
 
@@ -266,7 +265,7 @@ def eq_ignore_whitespace(a, b, msg=None):
     b = re.sub(r'^\s+?|\n', "", b)
     b = re.sub(r' {2,}', " ", b)
 
-    assert a == b, msg or "%r != %r" % (a, b)
+    assert a == b, msg or "{0!r} != {1!r}".format(a, b)
 
 
 def assert_raises(except_cls, callable_, *args, **kw):
@@ -286,7 +285,7 @@ def assert_raises_message(except_cls, msg, callable_, *args, **kwargs):
         assert False, "Callable did not raise an exception"
     except except_cls as e:
         assert re.search(
-            msg, util.text_type(e), re.UNICODE), "%r !~ %s" % (msg, e)
+            msg, util.text_type(e), re.UNICODE), "{0!r} !~ {1!s}".format(msg, e)
         print(util.text_type(e).encode('utf-8'))
 
 
@@ -354,7 +353,7 @@ class AssertsCompiledSQL(object):
 
         cc = re.sub(r'[\n\t]', '', util.text_type(c))
 
-        eq_(cc, result, "%r != %r on dialect %r" % (cc, result, dialect))
+        eq_(cc, result, "{0!r} != {1!r} on dialect {2!r}".format(cc, result, dialect))
 
         if checkparams is not None:
             eq_(c.construct_params(params), checkparams)
@@ -398,8 +397,7 @@ class ComparesTables(object):
 
     def assert_types_base(self, c1, c2):
         assert c1.type._compare_type_affinity(c2.type), \
-            "On column %r, type '%s' doesn't correspond to type '%s'" % \
-            (c1.name, c1.type, c2.type)
+            "On column {0!r}, type '{1!s}' doesn't correspond to type '{2!s}'".format(c1.name, c1.type, c2.type)
 
 
 class AssertsExecutionResults(object):
@@ -426,7 +424,7 @@ class AssertsExecutionResults(object):
                     self.assert_row(value[0], getattr(rowobj, key), value[1])
             else:
                 self.assert_(getattr(rowobj, key) == value,
-                             "attribute %s value %s does not match %s" % (
+                             "attribute {0!s} value {1!s} does not match {2!s}".format(
                                  key, getattr(rowobj, key), value))
 
     def assert_unordered_result(self, result, cls, *expected):
@@ -445,11 +443,11 @@ class AssertsExecutionResults(object):
 
         for wrong in util.itertools_filterfalse(lambda o:
                                                 isinstance(o, cls), found):
-            fail('Unexpected type "%s", expected "%s"' % (
+            fail('Unexpected type "{0!s}", expected "{1!s}"'.format(
                 type(wrong).__name__, cls.__name__))
 
         if len(found) != len(expected):
-            fail('Unexpected object count "%s", expected "%s"' % (
+            fail('Unexpected object count "{0!s}", expected "{1!s}"'.format(
                 len(found), len(expected)))
 
         NOVALUE = object()
@@ -474,7 +472,7 @@ class AssertsExecutionResults(object):
                     break
             else:
                 fail(
-                    "Expected %s instance with attributes %s not found." % (
+                    "Expected {0!s} instance with attributes {1!s} not found.".format(
                         cls.__name__, repr(expected_item)))
         return True
 

--- a/lib/sqlalchemy/testing/assertsql.py
+++ b/lib/sqlalchemy/testing/assertsql.py
@@ -45,7 +45,7 @@ class CursorSQL(SQLMatchRule):
         if self.statement != stmt.statement or (
                         self.params is not None and self.params != stmt.parameters):
             self.errormessage = \
-                "Testing for exact SQL %s parameters %s received %s %s" % (
+                "Testing for exact SQL {0!s} parameters {1!s} received {2!s} {3!s}".format(
                     self.statement, self.params,
                     stmt.statement, stmt.parameters
                 )
@@ -254,8 +254,7 @@ class CountStatements(AssertRule):
 
     def no_more_statements(self):
         if self.count != self._statement_count:
-            assert False, 'desired statement count %d does not match %d' \
-                          % (self.count, self._statement_count)
+            assert False, 'desired statement count {0:d} does not match {1:d}'.format(self.count, self._statement_count)
 
 
 class AllOf(AssertRule):

--- a/lib/sqlalchemy/testing/engines.py
+++ b/lib/sqlalchemy/testing/engines.py
@@ -152,7 +152,7 @@ def all_dialects(exclude=None):
         mod = getattr(d, name, None)
         if not mod:
             mod = getattr(__import__(
-                'sqlalchemy.databases.%s' % name).databases, name)
+                'sqlalchemy.databases.{0!s}'.format(name)).databases, name)
         yield mod.dialect()
 
 

--- a/lib/sqlalchemy/testing/entities.py
+++ b/lib/sqlalchemy/testing/entities.py
@@ -21,9 +21,9 @@ class BasicEntity(object):
             return object.__repr__(self)
         _repr_stack.add(id(self))
         try:
-            return "%s(%s)" % (
+            return "{0!s}({1!s})".format(
                 (self.__class__.__name__),
-                ', '.join(["%s=%r" % (key, getattr(self, key))
+                ', '.join(["{0!s}={1!r}".format(key, getattr(self, key))
                            for key in sorted(self.__dict__.keys())
                            if not key.startswith('_')]))
         finally:

--- a/lib/sqlalchemy/testing/exclusions.py
+++ b/lib/sqlalchemy/testing/exclusions.py
@@ -113,7 +113,7 @@ class compound(object):
     def _do(self, config, fn, *args, **kw):
         for skip in self.skips:
             if skip(config):
-                msg = "'%s' : %s" % (
+                msg = "'{0!s}' : {1!s}".format(
                     fn.__name__,
                     skip._as_string(config)
                 )
@@ -130,7 +130,7 @@ class compound(object):
     def _expect_failure(self, config, ex, name='block'):
         for fail in self.fails:
             if fail(config):
-                print(("%s failed as expected (%s): %s " % (
+                print(("{0!s} failed as expected ({1!s}): {2!s} ".format(
                     name, fail._as_string(config), str(ex))))
                 break
         else:
@@ -144,8 +144,7 @@ class compound(object):
                 break
         else:
             raise AssertionError(
-                "Unexpected success for '%s' (%s)" %
-                (
+                "Unexpected success for '{0!s}' ({1!s})".format(
                     name,
                     " and ".join(
                         fail._as_string(config)
@@ -202,7 +201,7 @@ class Predicate(object):
         elif util.callable(predicate):
             return LambdaPredicate(predicate, description)
         else:
-            assert False, "unknown predicate type: %s" % predicate
+            assert False, "unknown predicate type: {0!s}".format(predicate)
 
     def _format_description(self, config, negate=False):
         bool_ = self(config)
@@ -222,7 +221,7 @@ class Predicate(object):
 class BooleanPredicate(Predicate):
     def __init__(self, value, description=None):
         self.value = value
-        self.description = description or "boolean %s" % value
+        self.description = description or "boolean {0!s}".format(value)
 
     def __call__(self, config):
         return self.value
@@ -277,18 +276,18 @@ class SpecPredicate(Predicate):
             return self._format_description(config)
         elif self.op is None:
             if negate:
-                return "not %s" % self.db
+                return "not {0!s}".format(self.db)
             else:
-                return "%s" % self.db
+                return "{0!s}".format(self.db)
         else:
             if negate:
-                return "not %s %s %s" % (
+                return "not {0!s} {1!s} {2!s}".format(
                     self.db,
                     self.op,
                     self.spec
                 )
             else:
-                return "%s %s %s" % (
+                return "{0!s} {1!s} {2!s}".format(
                     self.db,
                     self.op,
                     self.spec

--- a/lib/sqlalchemy/testing/fixtures.py
+++ b/lib/sqlalchemy/testing/fixtures.py
@@ -140,7 +140,7 @@ class TablesTest(TestBase):
                         conn.execute(table.delete())
                     except sa.exc.DBAPIError as ex:
                         util.print_(
-                            ("Error emptying table %s: %r" % (table, ex)),
+                            ("Error emptying table {0!s}: {1!r}".format(table, ex)),
                             file=sys.stderr)
 
     def setup(self):

--- a/lib/sqlalchemy/testing/pickleable.py
+++ b/lib/sqlalchemy/testing/pickleable.py
@@ -78,7 +78,7 @@ class Bar(object):
                other.y == self.y
 
     def __str__(self):
-        return "Bar(%d, %d)" % (self.x, self.y)
+        return "Bar({0:d}, {1:d})".format(self.x, self.y)
 
 
 class OldSchool:
@@ -104,7 +104,7 @@ class BarWithoutCompare(object):
         self.y = y
 
     def __str__(self):
-        return "Bar(%d, %d)" % (self.x, self.y)
+        return "Bar({0:d}, {1:d})".format(self.x, self.y)
 
 
 class NotComparable(object):

--- a/lib/sqlalchemy/testing/plugin/bootstrap.py
+++ b/lib/sqlalchemy/testing/plugin/bootstrap.py
@@ -25,7 +25,7 @@ to_bootstrap = locals()['to_bootstrap']
 
 
 def load_file_as_module(name):
-    path = os.path.join(os.path.dirname(bootstrap_file), "%s.py" % name)
+    path = os.path.join(os.path.dirname(bootstrap_file), "{0!s}.py".format(name))
     if sys.version_info >= (3, 3):
         from importlib import machinery
         mod = machinery.SourceFileLoader(name, path).load_module()
@@ -42,4 +42,4 @@ elif to_bootstrap == "nose":
     sys.modules["sqla_plugin_base"] = load_file_as_module("plugin_base")
     sys.modules["sqla_noseplugin"] = load_file_as_module("noseplugin")
 else:
-    raise Exception("unknown bootstrap: %s" % to_bootstrap)  # noqa
+    raise Exception("unknown bootstrap: {0!s}".format(to_bootstrap))  # noqa

--- a/lib/sqlalchemy/testing/plugin/plugin_base.py
+++ b/lib/sqlalchemy/testing/plugin/plugin_base.py
@@ -192,7 +192,7 @@ def _log(opt_str, value, parser):
 def _list_dbs(*args):
     print("Available --db options (use --dburi to override)")
     for macro in sorted(file_config.options('db')):
-        print("%20s\t%s" % (macro, file_config.get('db', macro)))
+        print("{0:20!s}\t{1!s}".format(macro, file_config.get('db', macro)))
     sys.exit(0)
 
 
@@ -407,12 +407,12 @@ def want_method(cls, fn):
 def generate_sub_tests(cls, module):
     if getattr(cls, '__backend__', False):
         for cfg in _possible_configs_for_cls(cls):
-            name = "%s_%s_%s" % (cls.__name__, cfg.db.name, cfg.db.driver)
+            name = "{0!s}_{1!s}_{2!s}".format(cls.__name__, cfg.db.name, cfg.db.driver)
             subcls = type(
                 name,
                 (cls,),
                 {
-                    "__only_on__": ("%s+%s" % (cfg.db.name, cfg.db.driver)),
+                    "__only_on__": ("{0!s}+{1!s}".format(cfg.db.name, cfg.db.driver)),
                 }
             )
             setattr(module, name, subcls)
@@ -458,11 +458,11 @@ def before_test(test, test_module_name, test_class, test_name):
     # "test.aaa_profiling.test_compiler.CompileTest.test_update_whereclause"
     name = test_class.__name__
 
-    suffix = "_%s_%s" % (config.db.name, config.db.driver)
+    suffix = "_{0!s}_{1!s}".format(config.db.name, config.db.driver)
     if name.endswith(suffix):
         name = name[0:-(len(suffix))]
 
-    id_ = "%s.%s.%s" % (test_module_name, name, test_name)
+    id_ = "{0!s}.{1!s}.{2!s}".format(test_module_name, name, test_name)
 
     profiling._current_test = id_
 
@@ -521,19 +521,19 @@ def _do_skips(cls):
     if getattr(cls, '__skip_if__', False):
         for c in getattr(cls, '__skip_if__'):
             if c():
-                config.skip_test("'%s' skipped by %s" % (
+                config.skip_test("'{0!s}' skipped by {1!s}".format(
                     cls.__name__, c.__name__)
                                  )
 
     if not all_configs:
         if getattr(cls, '__backend__', False):
-            msg = "'%s' unsupported for implementation '%s'" % (
+            msg = "'{0!s}' unsupported for implementation '{1!s}'".format(
                 cls.__name__, cls.__only_on__)
         else:
-            msg = "'%s' unsupported on any DB implementation %s%s" % (
+            msg = "'{0!s}' unsupported on any DB implementation {1!s}{2!s}".format(
                 cls.__name__,
                 ", ".join(
-                    "'%s(%s)+%s'" % (
+                    "'{0!s}({1!s})+{2!s}'".format(
                         config_obj.db.name,
                         ".".join(
                             str(dig) for dig in

--- a/lib/sqlalchemy/testing/plugin/pytestplugin.py
+++ b/lib/sqlalchemy/testing/plugin/pytestplugin.py
@@ -80,7 +80,7 @@ if has_xdist:
 
         plugin_base.memoize_important_follower_config(node.slaveinput)
 
-        node.slaveinput["follower_ident"] = "test_%s" % uuid.uuid4().hex[0:12]
+        node.slaveinput["follower_ident"] = "test_{0!s}".format(uuid.uuid4().hex[0:12])
         from sqlalchemy.testing import provision
         provision.create_follower_db(node.slaveinput["follower_ident"])
 

--- a/lib/sqlalchemy/testing/profiling.py
+++ b/lib/sqlalchemy/testing/profiling.py
@@ -170,17 +170,17 @@ class ProfileStatsFile(object):
         profile_f.close()
 
     def _write(self):
-        print(("Writing profile file %s" % self.fname))
+        print(("Writing profile file {0!s}".format(self.fname)))
         profile_f = open(self.fname, "w")
         profile_f.write(self._header())
         for test_key in sorted(self.data):
 
             per_fn = self.data[test_key]
-            profile_f.write("\n# TEST: %s\n\n" % test_key)
+            profile_f.write("\n# TEST: {0!s}\n\n".format(test_key))
             for platform_key in sorted(per_fn):
                 per_platform = per_fn[platform_key]
                 c = ",".join(str(count) for count in per_platform['counts'])
-                profile_f.write("%s %s %s\n" % (test_key, platform_key, c))
+                profile_f.write("{0!s} {1!s} {2!s}\n".format(test_key, platform_key, c))
         profile_f.close()
 
 
@@ -239,7 +239,7 @@ def count_functions(variance=0.05):
     else:
         line_no, expected_count = expected
 
-    print(("Pstats calls: %d Expected %s" % (
+    print(("Pstats calls: {0:d} Expected {1!s}".format(
         callcount,
         expected_count
     )

--- a/lib/sqlalchemy/testing/provision.py
+++ b/lib/sqlalchemy/testing/provision.py
@@ -93,12 +93,12 @@ def _configs_for_db_operation():
 
 @register.init
 def _create_db(cfg, eng, ident):
-    raise NotImplementedError("no DB creation routine for cfg: %s" % eng.url)
+    raise NotImplementedError("no DB creation routine for cfg: {0!s}".format(eng.url))
 
 
 @register.init
 def _drop_db(cfg, eng, ident):
-    raise NotImplementedError("no DB drop routine for cfg: %s" % eng.url)
+    raise NotImplementedError("no DB drop routine for cfg: {0!s}".format(eng.url))
 
 
 @register.init
@@ -134,7 +134,7 @@ def _sqlite_follower_url_from_main(url, ident):
     if not url.database or url.database == ':memory:':
         return url
     else:
-        return sa_url.make_url("sqlite:///%s.db" % ident)
+        return sa_url.make_url("sqlite:///{0!s}.db".format(ident))
 
 
 @_post_configure_engine.for_db("sqlite")
@@ -150,8 +150,7 @@ def _sqlite_post_configure_engine(url, engine, follower_ident):
                 'ATTACH DATABASE "test_schema.db" AS test_schema')
         else:
             dbapi_connection.execute(
-                'ATTACH DATABASE "%s_test_schema.db" AS test_schema'
-                % follower_ident)
+                'ATTACH DATABASE "{0!s}_test_schema.db" AS test_schema'.format(follower_ident))
 
 
 @_create_db.for_db("postgresql")
@@ -166,7 +165,7 @@ def _pg_create_db(cfg, eng, ident):
         for attempt in range(3):
             try:
                 conn.execute(
-                    "CREATE DATABASE %s TEMPLATE %s" % (ident, currentdb))
+                    "CREATE DATABASE {0!s} TEMPLATE {1!s}".format(ident, currentdb))
             except exc.OperationalError as err:
                 if attempt != 2 and "accessed by other users" in str(err):
                     time.sleep(.2)
@@ -184,15 +183,15 @@ def _mysql_create_db(cfg, eng, ident):
             _mysql_drop_db(cfg, conn, ident)
         except Exception:
             pass
-        conn.execute("CREATE DATABASE %s" % ident)
-        conn.execute("CREATE DATABASE %s_test_schema" % ident)
-        conn.execute("CREATE DATABASE %s_test_schema_2" % ident)
+        conn.execute("CREATE DATABASE {0!s}".format(ident))
+        conn.execute("CREATE DATABASE {0!s}_test_schema".format(ident))
+        conn.execute("CREATE DATABASE {0!s}_test_schema_2".format(ident))
 
 
 @_configure_follower.for_db("mysql")
 def _mysql_configure_follower(config, ident):
-    config.test_schema = "%s_test_schema" % ident
-    config.test_schema_2 = "%s_test_schema_2" % ident
+    config.test_schema = "{0!s}_test_schema".format(ident)
+    config.test_schema_2 = "{0!s}_test_schema_2".format(ident)
 
 
 @_create_db.for_db("sqlite")
@@ -210,23 +209,23 @@ def _pg_drop_db(cfg, eng, ident):
                 "where usename=current_user and pid != pg_backend_pid() "
                 "and datname=:dname"
             ), dname=ident)
-        conn.execute("DROP DATABASE %s" % ident)
+        conn.execute("DROP DATABASE {0!s}".format(ident))
 
 
 @_drop_db.for_db("sqlite")
 def _sqlite_drop_db(cfg, eng, ident):
     if ident:
-        os.remove("%s_test_schema.db" % ident)
+        os.remove("{0!s}_test_schema.db".format(ident))
     else:
-        os.remove("%s.db" % ident)
+        os.remove("{0!s}.db".format(ident))
 
 
 @_drop_db.for_db("mysql")
 def _mysql_drop_db(cfg, eng, ident):
     with eng.connect() as conn:
-        conn.execute("DROP DATABASE %s_test_schema" % ident)
-        conn.execute("DROP DATABASE %s_test_schema_2" % ident)
-        conn.execute("DROP DATABASE %s" % ident)
+        conn.execute("DROP DATABASE {0!s}_test_schema".format(ident))
+        conn.execute("DROP DATABASE {0!s}_test_schema_2".format(ident))
+        conn.execute("DROP DATABASE {0!s}".format(ident))
 
 
 @_create_db.for_db("oracle")
@@ -235,24 +234,24 @@ def _oracle_create_db(cfg, eng, ident):
     # similar, so that the default tablespace is not "system"; reflection will
     # fail otherwise
     with eng.connect() as conn:
-        conn.execute("create user %s identified by xe" % ident)
-        conn.execute("create user %s_ts1 identified by xe" % ident)
-        conn.execute("create user %s_ts2 identified by xe" % ident)
-        conn.execute("grant dba to %s" % (ident,))
-        conn.execute("grant unlimited tablespace to %s" % ident)
-        conn.execute("grant unlimited tablespace to %s_ts1" % ident)
-        conn.execute("grant unlimited tablespace to %s_ts2" % ident)
+        conn.execute("create user {0!s} identified by xe".format(ident))
+        conn.execute("create user {0!s}_ts1 identified by xe".format(ident))
+        conn.execute("create user {0!s}_ts2 identified by xe".format(ident))
+        conn.execute("grant dba to {0!s}".format(ident))
+        conn.execute("grant unlimited tablespace to {0!s}".format(ident))
+        conn.execute("grant unlimited tablespace to {0!s}_ts1".format(ident))
+        conn.execute("grant unlimited tablespace to {0!s}_ts2".format(ident))
 
 
 @_configure_follower.for_db("oracle")
 def _oracle_configure_follower(config, ident):
-    config.test_schema = "%s_ts1" % ident
-    config.test_schema_2 = "%s_ts2" % ident
+    config.test_schema = "{0!s}_ts1".format(ident)
+    config.test_schema_2 = "{0!s}_ts2".format(ident)
 
 
 def _ora_drop_ignore(conn, dbname):
     try:
-        conn.execute("drop user %s cascade" % dbname)
+        conn.execute("drop user {0!s} cascade".format(dbname))
         log.info("Reaped db: %s", dbname)
         return True
     except exc.DatabaseError as err:
@@ -269,8 +268,8 @@ def _oracle_drop_db(cfg, eng, ident):
         # while there is a "kill session" command in Oracle,
         # it unfortunately does not release the connection sufficiently.
         _ora_drop_ignore(conn, ident)
-        _ora_drop_ignore(conn, "%s_ts1" % ident)
-        _ora_drop_ignore(conn, "%s_ts2" % ident)
+        _ora_drop_ignore(conn, "{0!s}_ts1".format(ident))
+        _ora_drop_ignore(conn, "{0!s}_ts2".format(ident))
 
 
 def reap_oracle_dbs(eng, idents_file):
@@ -292,10 +291,10 @@ def reap_oracle_dbs(eng, idents_file):
                 continue
             elif name in idents:
                 to_drop.add(name)
-                if "%s_ts1" % name in all_names:
-                    to_drop.add("%s_ts1" % name)
-                if "%s_ts2" % name in all_names:
-                    to_drop.add("%s_ts2" % name)
+                if "{0!s}_ts1".format(name) in all_names:
+                    to_drop.add("{0!s}_ts1".format(name))
+                if "{0!s}_ts2".format(name) in all_names:
+                    to_drop.add("{0!s}_ts2".format(name))
 
         dropped = total = 0
         for total, username in enumerate(to_drop, 1):

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -65,8 +65,8 @@ class ComponentReflectionTest(fixtures.TablesTest):
                           Column('test1', sa.CHAR(5), nullable=False),
                           Column('test2', sa.Float(5), nullable=False),
                           Column('parent_user_id', sa.Integer,
-                                 sa.ForeignKey('%susers.user_id' %
-                                               schema_prefix)),
+                                 sa.ForeignKey('{0!s}users.user_id'.format(
+                                               schema_prefix))),
                           schema=schema,
                           test_needs_fk=True,
                           )
@@ -82,8 +82,8 @@ class ComponentReflectionTest(fixtures.TablesTest):
         Table("dingalings", metadata,
               Column('dingaling_id', sa.Integer, primary_key=True),
               Column('address_id', sa.Integer,
-                     sa.ForeignKey('%semail_addresses.address_id' %
-                                   schema_prefix)),
+                     sa.ForeignKey('{0!s}email_addresses.address_id'.format(
+                                   schema_prefix))),
               Column('data', sa.String(30)),
               schema=schema,
               test_needs_fk=True,
@@ -150,9 +150,9 @@ class ComponentReflectionTest(fixtures.TablesTest):
         for table_name in ('users', 'email_addresses'):
             fullname = table_name
             if schema:
-                fullname = "%s.%s" % (schema, table_name)
+                fullname = "{0!s}.{1!s}".format(schema, table_name)
             view_name = fullname + '_v'
-            query = "CREATE VIEW %s AS SELECT * FROM %s" % (
+            query = "CREATE VIEW {0!s} AS SELECT * FROM {1!s}".format(
                 view_name, fullname)
 
             event.listen(
@@ -163,7 +163,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
             event.listen(
                 metadata,
                 "before_drop",
-                DDL("DROP VIEW %s" % view_name)
+                DDL("DROP VIEW {0!s}".format(view_name))
             )
 
     @testing.requires.schema_reflection
@@ -293,8 +293,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
                     sql_types.Time,
                     sql_types.String,
                     sql_types._Binary,
-                ])) > 0, '%s(%s), %s(%s)' %
-                             (col.name, col.type, cols[i]['name'], ctype))
+                ])) > 0, '{0!s}({1!s}), {2!s}({3!s})'.format(col.name, col.type, cols[i]['name'], ctype))
 
                 if not col.primary_key:
                     assert cols[i]['default'] is None
@@ -307,7 +306,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
     def _type_round_trip(self, *types):
         t = Table('t', self.metadata,
                   *[
-                      Column('t%d' % i, type_)
+                      Column('t{0:d}'.format(i), type_)
                       for i, type_ in enumerate(types)
                       ]
                   )

--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -96,7 +96,7 @@ class KeyedTuple(AbstractKeyedTuple):
         return tuple([l for l in self._labels if l is not None])
 
     def __setattr__(self, key, value):
-        raise AttributeError("Can't set attribute: %s" % key)
+        raise AttributeError("Can't set attribute: {0!s}".format(key))
 
     def _asdict(self):
         """Return the contents of this :class:`.KeyedTuple` as a dictionary.
@@ -132,7 +132,7 @@ class _LW(AbstractKeyedTuple):
 
 class ImmutableContainer(object):
     def _immutable(self, *arg, **kw):
-        raise TypeError("%s object is immutable" % self.__class__.__name__)
+        raise TypeError("{0!s} object is immutable".format(self.__class__.__name__))
 
     __delitem__ = __setitem__ = __setattr__ = _immutable
 
@@ -166,7 +166,7 @@ class immutabledict(ImmutableContainer, dict):
             return d2
 
     def __repr__(self):
-        return "immutabledict(%s)" % dict.__repr__(self)
+        return "immutabledict({0!s})".format(dict.__repr__(self))
 
 
 class Properties(object):
@@ -398,7 +398,7 @@ class OrderedSet(set):
         return self.union(other)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self._list)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self._list)
 
     __str__ = __repr__
 
@@ -666,7 +666,7 @@ class IdentitySet(object):
         raise TypeError('set objects are unhashable')
 
     def __repr__(self):
-        return '%s(%r)' % (type(self).__name__, list(self._members.values()))
+        return '{0!s}({1!r})'.format(type(self).__name__, list(self._members.values()))
 
 
 class WeakSequence(object):
@@ -692,7 +692,7 @@ class WeakSequence(object):
         try:
             obj = self._storage[index]
         except KeyError:
-            raise IndexError("Index %s out of range" % index)
+            raise IndexError("Index {0!s} out of range".format(index))
         else:
             return obj()
 

--- a/lib/sqlalchemy/util/deprecations.py
+++ b/lib/sqlalchemy/util/deprecations.py
@@ -37,8 +37,7 @@ def deprecated(version, message=None, add_deprecation_to_docstring=True):
     """
 
     if add_deprecation_to_docstring:
-        header = ".. deprecated:: %s %s" % \
-                 (version, (message or ''))
+        header = ".. deprecated:: {0!s} {1!s}".format(version, (message or ''))
     else:
         header = None
 
@@ -72,8 +71,7 @@ def pending_deprecation(version, message=None,
     """
 
     if add_deprecation_to_docstring:
-        header = ".. deprecated:: %s (pending) %s" % \
-                 (version, (message or ''))
+        header = ".. deprecated:: {0!s} (pending) {1!s}".format(version, (message or ''))
     else:
         header = None
 

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -96,7 +96,7 @@ def _unique_symbols(used, *bases):
                 yield sym
                 break
         else:
-            raise NameError("exhausted namespace for symbol base %s" % base)
+            raise NameError("exhausted namespace for symbol base {0!s}".format(base))
 
 
 def map_bits(fn, n):
@@ -122,9 +122,9 @@ def decorator(target):
         metadata.update(format_argspec_plus(spec, grouped=False))
         metadata['name'] = fn.__name__
         code = """\
-def %(name)s(%(args)s):
-    return %(target)s(%(fn)s, %(apply_kw)s)
-""" % metadata
+def {name!s}({args!s}):
+    return {target!s}({fn!s}, {apply_kw!s})
+""".format(**metadata)
         decorated = _exec_code_in_env(code,
                                       {targ_name: target, fn_name: fn},
                                       fn.__name__)
@@ -166,9 +166,9 @@ def public_factory(target, location):
     metadata = format_argspec_plus(spec, grouped=False)
     metadata['name'] = location_name
     code = """\
-def %(name)s(%(args)s):
-    return cls(%(apply_kw)s)
-""" % metadata
+def {name!s}({args!s}):
+    return cls({apply_kw!s})
+""".format(**metadata)
     env = {'cls': callable_, 'symbol': symbol}
     exec (code, env)
     decorated = env[location_name]
@@ -208,8 +208,7 @@ class PluginLoader(object):
                 return impl.load()
 
         raise exc.NoSuchModuleError(
-            "Can't load plugin: %s:%s" %
-            (self.group, name))
+            "Can't load plugin: {0!s}:{1!s}".format(self.group, name))
 
     def register(self, name, modulepath, objname):
         def load():
@@ -298,7 +297,7 @@ def get_callable_argspec(fn, no_self=False, _is_init=False):
 
     """
     if inspect.isbuiltin(fn):
-        raise TypeError("Can't inspect builtin: %s" % fn)
+        raise TypeError("Can't inspect builtin: {0!s}".format(fn))
     elif inspect.isfunction(fn):
         if _is_init and no_self:
             spec = compat.inspect_getargspec(fn)
@@ -322,9 +321,9 @@ def get_callable_argspec(fn, no_self=False, _is_init=False):
         if inspect.ismethod(fn.__call__):
             return get_callable_argspec(fn.__call__, no_self=no_self)
         else:
-            raise TypeError("Can't inspect callable: %s" % fn)
+            raise TypeError("Can't inspect callable: {0!s}".format(fn))
     else:
-        raise TypeError("Can't inspect callable: %s" % fn)
+        raise TypeError("Can't inspect callable: {0!s}".format(fn))
 
 
 def format_argspec_plus(fn, grouped=True):
@@ -368,7 +367,7 @@ def format_argspec_plus(fn, grouped=True):
     if spec[0]:
         self_arg = spec[0][0]
     elif spec[1]:
-        self_arg = '%s[0]' % spec[1]
+        self_arg = '{0!s}[0]'.format(spec[1])
     else:
         self_arg = None
 
@@ -510,7 +509,7 @@ def generic_repr(obj, additional_kw=(), to_inspect=None, omit_kwarg=()):
         try:
             val = getattr(obj, arg, missing)
             if val is not missing and val != defval:
-                output.append('%s=%r' % (arg, val))
+                output.append('{0!s}={1!r}'.format(arg, val))
         except Exception:
             pass
 
@@ -519,11 +518,11 @@ def generic_repr(obj, additional_kw=(), to_inspect=None, omit_kwarg=()):
             try:
                 val = getattr(obj, arg, missing)
                 if val is not missing and val != defval:
-                    output.append('%s=%r' % (arg, val))
+                    output.append('{0!s}={1!r}'.format(arg, val))
             except Exception:
                 pass
 
-    return "%s(%s)" % (obj.__class__.__name__, ", ".join(output))
+    return "{0!s}({1!s})".format(obj.__class__.__name__, ", ".join(output))
 
 
 class portable_instancemethod(object):
@@ -718,7 +717,7 @@ def as_interface(obj, cls=None, methods=None, required=None):
     # No dict duck typing here.
     if not isinstance(obj, dict):
         qualifier = complies is operator.gt and 'any of' or 'all of'
-        raise TypeError("%r does not implement %s: %s" % (
+        raise TypeError("{0!r} does not implement {1!s}: {2!s}".format(
             obj, qualifier, ', '.join(interface)))
 
     class AnonymousInterface(object):
@@ -730,17 +729,17 @@ def as_interface(obj, cls=None, methods=None, required=None):
 
     for method, impl in dictlike_iteritems(obj):
         if method not in interface:
-            raise TypeError("%r: unknown in this interface" % method)
+            raise TypeError("{0!r}: unknown in this interface".format(method))
         if not compat.callable(impl):
-            raise TypeError("%r=%r is not callable" % (method, impl))
+            raise TypeError("{0!r}={1!r} is not callable".format(method, impl))
         setattr(AnonymousInterface, method, staticmethod(impl))
         found.add(method)
 
     if complies(found, required):
         return AnonymousInterface
 
-    raise TypeError("dictionary does not contain required keys %s" %
-                    ', '.join(required - found))
+    raise TypeError("dictionary does not contain required keys {0!s}".format(
+                    ', '.join(required - found)))
 
 
 class memoized_property(object):
@@ -824,12 +823,12 @@ class MemoizedSlots(object):
     def __getattr__(self, key):
         if key.startswith('_memoized'):
             raise AttributeError(key)
-        elif hasattr(self, '_memoized_attr_%s' % key):
-            value = getattr(self, '_memoized_attr_%s' % key)()
+        elif hasattr(self, '_memoized_attr_{0!s}'.format(key)):
+            value = getattr(self, '_memoized_attr_{0!s}'.format(key))()
             setattr(self, key, value)
             return value
-        elif hasattr(self, '_memoized_method_%s' % key):
-            fn = getattr(self, '_memoized_method_%s' % key)
+        elif hasattr(self, '_memoized_method_{0!s}'.format(key)):
+            fn = getattr(self, '_memoized_method_{0!s}'.format(key))
 
             def oneshot(*args, **kw):
                 result = fn(*args, **kw)
@@ -896,7 +895,7 @@ class dependencies(object):
         hasself = spec_zero[0] in ('self', 'cls')
 
         for i in range(len(import_deps)):
-            spec[0][i + (1 if hasself else 0)] = "import_deps[%r]" % i
+            spec[0][i + (1 if hasself else 0)] = "import_deps[{0!r}]".format(i)
 
         inner_spec = format_argspec_plus(spec, grouped=False)
 
@@ -906,10 +905,10 @@ class dependencies(object):
 
         outer_spec = format_argspec_plus(spec, grouped=False)
 
-        code = 'lambda %(args)s: fn(%(apply_kw)s)' % {
+        code = 'lambda {args!s}: fn({apply_kw!s})'.format(**{
             "args": outer_spec['args'],
             "apply_kw": inner_spec['apply_kw']
-        }
+        })
 
         decorated = eval(code, locals())
         decorated.__defaults__ = getattr(fn, 'im_func', fn).__defaults__
@@ -964,14 +963,12 @@ class dependencies(object):
 
         def __getattr__(self, key):
             if key == 'module':
-                raise ImportError("Could not resolve module %s"
-                                  % self._full_path)
+                raise ImportError("Could not resolve module {0!s}".format(self._full_path))
             try:
                 attr = getattr(self.module, key)
             except AttributeError:
                 raise AttributeError(
-                    "Module %s has no attribute '%s'" %
-                    (self._full_path, key)
+                    "Module {0!s} has no attribute '{1!s}'".format(self._full_path, key)
                 )
             self.__dict__[key] = attr
             return attr
@@ -986,7 +983,7 @@ def asbool(obj):
         elif obj in ['false', 'no', 'off', 'n', 'f', '0']:
             return False
         else:
-            raise ValueError("String is not true/false: %r" % obj)
+            raise ValueError("String is not true/false: {0!r}".format(obj))
     return bool(obj)
 
 
@@ -1095,12 +1092,10 @@ def assert_arg_type(arg, argtype, name):
     else:
         if isinstance(argtype, tuple):
             raise exc.ArgumentError(
-                "Argument '%s' is expected to be one of type %s, got '%s'" %
-                (name, ' or '.join("'%s'" % a for a in argtype), type(arg)))
+                "Argument '{0!s}' is expected to be one of type {1!s}, got '{2!s}'".format(name, ' or '.join("'{0!s}'".format(a) for a in argtype), type(arg)))
         else:
             raise exc.ArgumentError(
-                "Argument '%s' is expected to be of type '%s', got '%s'" %
-                (name, argtype, type(arg)))
+                "Argument '{0!s}' is expected to be of type '{1!s}', got '{2!s}'".format(name, argtype, type(arg)))
 
 
 def dictlike_iteritems(dictlike):
@@ -1118,7 +1113,7 @@ def dictlike_iteritems(dictlike):
     getter = getattr(dictlike, '__getitem__', getattr(dictlike, 'get', None))
     if getter is None:
         raise TypeError(
-            "Object '%r' is not dict-like" % dictlike)
+            "Object '{0!r}' is not dict-like".format(dictlike))
 
     if hasattr(dictlike, 'iterkeys'):
         def iterator():
@@ -1130,7 +1125,7 @@ def dictlike_iteritems(dictlike):
         return iter((key, getter(key)) for key in dictlike.keys())
     else:
         raise TypeError(
-            "Object '%r' is not dict-like" % dictlike)
+            "Object '{0!r}' is not dict-like".format(dictlike))
 
 
 class classproperty(property):
@@ -1197,7 +1192,7 @@ class _symbol(int):
         return repr(self)
 
     def __repr__(self):
-        return "symbol(%r)" % self.name
+        return "symbol({0!r})".format(self.name)
 
 
 _symbol.__name__ = 'symbol'
@@ -1262,13 +1257,13 @@ def warn_exception(func, *args, **kwargs):
     try:
         return func(*args, **kwargs)
     except Exception:
-        warn("%s('%s') ignored" % sys.exc_info()[0:2])
+        warn("{0!s}('{1!s}') ignored".format(*sys.exc_info()[0:2]))
 
 
 def ellipses_string(value, len_=25):
     try:
         if len(value) > len_:
-            return "%s..." % value[0:len_]
+            return "{0!s}...".format(value[0:len_])
         else:
             return value
     except TypeError:
@@ -1289,9 +1284,9 @@ class _hash_limit_string(compat.text_type):
     def __new__(cls, value, num, args):
         interpolated = (value % args) + \
                        (
-                       " (this warning may be suppressed after %d occurrences)" % num)
+                       " (this warning may be suppressed after {0:d} occurrences)".format(num))
         self = super(_hash_limit_string, cls).__new__(cls, interpolated)
-        self._hash = hash("%s_%d" % (value, hash(interpolated) % num))
+        self._hash = hash("{0!s}_{1:d}".format(value, hash(interpolated) % num))
         return self
 
     def __hash__(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
