### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/adjacency_list/adjacency_list.py
+++ b/examples/adjacency_list/adjacency_list.py
@@ -33,7 +33,7 @@ class TreeNode(Base):
         self.parent = parent
 
     def __repr__(self):
-        return "TreeNode(name=%r, id=%r, parent_id=%r)" % (
+        return "TreeNode(name={0!r}, id={1!r}, parent_id={2!r})".format(
                     self.name,
                     self.id,
                     self.parent_id

--- a/examples/association/basic_association.py
+++ b/examples/association/basic_association.py
@@ -44,7 +44,7 @@ class Item(Base):
         self.price = price
 
     def __repr__(self):
-        return 'Item(%r, %r)' % (
+        return 'Item({0!r}, {1!r})'.format(
                     self.description, self.price
                 )
 

--- a/examples/association/proxied_association.py
+++ b/examples/association/proxied_association.py
@@ -41,7 +41,7 @@ class Item(Base):
         self.price = price
 
     def __repr__(self):
-        return 'Item(%r, %r)' % (
+        return 'Item({0!r}, {1!r})'.format(
                     self.description, self.price
                 )
 

--- a/examples/custom_attributes/listen_for_events.py
+++ b/examples/custom_attributes/listen_for_events.py
@@ -30,10 +30,10 @@ if __name__ == '__main__':
     class Base(object):
 
         def receive_change_event(self, verb, key, value, oldvalue):
-            s = "Value '%s' %s on attribute '%s', " % (value, verb, key)
+            s = "Value '{0!s}' {1!s} on attribute '{2!s}', ".format(value, verb, key)
             if oldvalue:
-                s += "which replaced the value '%s', " % oldvalue
-            s += "on object %s" % self
+                s += "which replaced the value '{0!s}', ".format(oldvalue)
+            s += "on object {0!s}".format(self)
             print(s)
 
     Base = declarative_base(cls=Base)
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         related = relationship("Related", backref="mapped")
 
         def __str__(self):
-            return "MyMappedClass(data=%r)" % self.data
+            return "MyMappedClass(data={0!r})".format(self.data)
 
     class Related(Base):
         __tablename__ = "related"
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         data = Column(String(50))
 
         def __str__(self):
-            return "Related(data=%r)" % self.data
+            return "Related(data={0!r})".format(self.data)
 
     # classes are instrumented.  Demonstrate the events !
 

--- a/examples/dogpile_caching/advanced.py
+++ b/examples/dogpile_caching/advanced.py
@@ -27,7 +27,7 @@ def load_name_range(start, end, invalidate=False):
     of data within the cache.
     """
     q = Session.query(Person).\
-            filter(Person.name.between("person %.2d" % start, "person %.2d" % end)).\
+            filter(Person.name.between("person {0:.2d}".format(start), "person {0:.2d}".format(end))).\
             options(cache_address_bits).\
             options(FromCache("default", "name_range"))
 

--- a/examples/dogpile_caching/environment.py
+++ b/examples/dogpile_caching/environment.py
@@ -43,7 +43,7 @@ if not os.path.exists(root):
     os.makedirs(root)
 
 dbfile = os.path.join(root, "dogpile_demo.db")
-engine = create_engine('sqlite:///%s' % dbfile, echo=True)
+engine = create_engine('sqlite:///{0!s}'.format(dbfile), echo=True)
 Session.configure(bind=engine)
 
 

--- a/examples/dogpile_caching/fixture_data.py
+++ b/examples/dogpile_caching/fixture_data.py
@@ -37,9 +37,9 @@ def install():
 
     for i in range(1, 51):
         person = Person(
-                    "person %.2d" % i,
+                    "person {0:.2d}".format(i),
                     Address(
-                        street="street %.2d" % i,
+                        street="street {0:.2d}".format(i),
                         postal_code=all_post_codes[
                                 random.randint(0, len(all_post_codes) - 1)]
                     )

--- a/examples/dogpile_caching/model.py
+++ b/examples/dogpile_caching/model.py
@@ -89,7 +89,7 @@ class Person(Base):
         return self.name
 
     def __repr__(self):
-        return "Person(name=%r)" % self.name
+        return "Person(name={0!r})".format(self.name)
 
     def format_full(self):
         return "\t".join([str(x) for x in [self] + list(self.addresses)])

--- a/examples/dynamic_dict/dynamic_dict.py
+++ b/examples/dynamic_dict/dynamic_dict.py
@@ -53,7 +53,7 @@ class Child(Base):
     parent_id = Column(Integer, ForeignKey('parent.id'))
 
     def __repr__(self):
-        return "Child(key=%r)" % self.key
+        return "Child(key={0!r})".format(self.key)
 
 Base.metadata.create_all()
 

--- a/examples/elementtree/adjacency_list.py
+++ b/examples/elementtree/adjacency_list.py
@@ -201,6 +201,6 @@ for path, compareto in (
         ('/somefile/header/field2', 'there'),
         ('/somefile/header/field2[@attr=foo]', 'there')
     ):
-    print("\nDocuments containing '%s=%s':" % (path, compareto), line)
+    print("\nDocuments containing '{0!s}={1!s}':".format(path, compareto), line)
     print([d.filename for d in find_document(path, compareto)])
 

--- a/examples/elementtree/optimized_al.py
+++ b/examples/elementtree/optimized_al.py
@@ -210,6 +210,6 @@ for path, compareto in (
         ('/somefile/header/field2', 'there'),
         ('/somefile/header/field2[@attr=foo]', 'there')
     ):
-    print("\nDocuments containing '%s=%s':" % (path, compareto), line)
+    print("\nDocuments containing '{0!s}={1!s}':".format(path, compareto), line)
     print([d.filename for d in find_document(path, compareto)])
 

--- a/examples/generic_associations/discriminator_on_association.py
+++ b/examples/generic_associations/discriminator_on_association.py
@@ -62,8 +62,7 @@ class Address(Base):
     parent = association_proxy("association", "parent")
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -81,7 +80,7 @@ class HasAddresses(object):
         discriminator = name.lower()
 
         assoc_cls = type(
-                        "%sAddressAssociation" % name,
+                        "{0!s}AddressAssociation".format(name),
                         (AddressAssociation, ),
                         dict(
                             __tablename__=None,

--- a/examples/generic_associations/generic_fk.py
+++ b/examples/generic_associations/generic_fk.py
@@ -65,11 +65,10 @@ class Address(Base):
         the appropriate relationship.
 
         """
-        return getattr(self, "parent_%s" % self.discriminator)
+        return getattr(self, "parent_{0!s}".format(self.discriminator))
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -88,7 +87,7 @@ def setup_listener(mapper, class_):
                                         Address.discriminator == discriminator
                                     ),
                         backref=backref(
-                                "parent_%s" % discriminator,
+                                "parent_{0!s}".format(discriminator),
                                 primaryjoin=remote(class_.id) == foreign(Address.parent_id)
                                 )
                         )

--- a/examples/generic_associations/table_per_association.py
+++ b/examples/generic_associations/table_per_association.py
@@ -41,8 +41,7 @@ class Address(Base):
     zip = Column(String)
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -53,12 +52,12 @@ class HasAddresses(object):
     @declared_attr
     def addresses(cls):
         address_association = Table(
-            "%s_addresses" % cls.__tablename__,
+            "{0!s}_addresses".format(cls.__tablename__),
             cls.metadata,
             Column("address_id", ForeignKey("address.id"),
                                 primary_key=True),
-            Column("%s_id" % cls.__tablename__,
-                                ForeignKey("%s.id" % cls.__tablename__),
+            Column("{0!s}_id".format(cls.__tablename__),
+                                ForeignKey("{0!s}.id".format(cls.__tablename__)),
                                 primary_key=True),
         )
         return relationship(Address, secondary=address_association)

--- a/examples/generic_associations/table_per_related.py
+++ b/examples/generic_associations/table_per_related.py
@@ -47,8 +47,7 @@ class Address(object):
     zip = Column(String)
 
     def __repr__(self):
-        return "%s(street=%r, city=%r, zip=%r)" % \
-            (self.__class__.__name__, self.street,
+        return "{0!s}(street={1!r}, city={2!r}, zip={3!r})".format(self.__class__.__name__, self.street,
             self.city, self.zip)
 
 class HasAddresses(object):
@@ -59,13 +58,13 @@ class HasAddresses(object):
     @declared_attr
     def addresses(cls):
         cls.Address = type(
-            "%sAddress" % cls.__name__,
+            "{0!s}Address".format(cls.__name__),
             (Address, Base,),
             dict(
-                __tablename__="%s_address" %
-                            cls.__tablename__,
+                __tablename__="{0!s}_address".format(
+                            cls.__tablename__),
                 parent_id=Column(Integer,
-                            ForeignKey("%s.id" % cls.__tablename__)),
+                            ForeignKey("{0!s}.id".format(cls.__tablename__))),
                 parent=relationship(cls)
             )
         )

--- a/examples/inheritance/joined.py
+++ b/examples/inheritance/joined.py
@@ -17,7 +17,7 @@ class Company(Base):
                     cascade='all, delete-orphan')
 
     def __repr__(self):
-        return "Company %s" % self.name
+        return "Company {0!s}".format(self.name)
 
 class Person(Base):
     __tablename__ = 'person'
@@ -31,7 +31,7 @@ class Person(Base):
         'polymorphic_on':type
     }
     def __repr__(self):
-        return "Ordinary person %s" % self.name
+        return "Ordinary person {0!s}".format(self.name)
 
 class Engineer(Person):
     __tablename__ = 'engineer'
@@ -59,8 +59,7 @@ class Manager(Person):
         'polymorphic_identity':'manager',
     }
     def __repr__(self):
-        return "Manager %s, status %s, manager_name %s" % \
-                    (self.name, self.status, self.manager_name)
+        return "Manager {0!s}, status {1!s}, manager_name {2!s}".format(self.name, self.status, self.manager_name)
 
 
 engine = create_engine('sqlite://', echo=True)

--- a/examples/inheritance/single.py
+++ b/examples/inheritance/single.py
@@ -28,7 +28,7 @@ class Person(object):
         for key, value in kwargs.items():
             setattr(self, key, value)
     def __repr__(self):
-        return "Ordinary person %s" % self.name
+        return "Ordinary person {0!s}".format(self.name)
 class Engineer(Person):
     def __repr__(self):
         return "Engineer %s, status %s, engineer_name %s, "\
@@ -37,14 +37,13 @@ class Engineer(Person):
                         self.engineer_name, self.primary_language)
 class Manager(Person):
     def __repr__(self):
-        return "Manager %s, status %s, manager_name %s" % \
-                    (self.name, self.status, self.manager_name)
+        return "Manager {0!s}, status {1!s}, manager_name {2!s}".format(self.name, self.status, self.manager_name)
 class Company(object):
     def __init__(self, **kwargs):
         for key, value in kwargs.items():
             setattr(self, key, value)
     def __repr__(self):
-        return "Company %s" % self.name
+        return "Company {0!s}".format(self.name)
 
 person_mapper = mapper(Person, employees_table,
                        polymorphic_on=employees_table.c.type,

--- a/examples/join_conditions/threeway.py
+++ b/examples/join_conditions/threeway.py
@@ -46,7 +46,7 @@ class First(Base):
     partition_key = Column(String)
 
     def __repr__(self):
-        return ("First(%s, %s)" % (self.first_id, self.partition_key))
+        return ("First({0!s}, {1!s})".format(self.first_id, self.partition_key))
 
 class Second(Base):
     __tablename__ = 'second'
@@ -61,7 +61,7 @@ class Partitioned(Base):
     partition_key = Column(String, primary_key=True)
 
     def __repr__(self):
-        return ("Partitioned(%s, %s)" % (self.other_id, self.partition_key))
+        return ("Partitioned({0!s}, {1!s})".format(self.other_id, self.partition_key))
 
 
 j = join(Partitioned, Second, Partitioned.other_id == Second.other_id)

--- a/examples/nested_sets/nested_sets.py
+++ b/examples/nested_sets/nested_sets.py
@@ -27,7 +27,7 @@ class Employee(Base):
     right = Column("rgt", Integer, nullable=False)
 
     def __repr__(self):
-        return "Employee(%s, %d, %d)" % (self.emp, self.left, self.right)
+        return "Employee({0!s}, {1:d}, {2:d})".format(self.emp, self.left, self.right)
 
 @event.listens_for(Employee, "before_insert")
 def before_insert(mapper, connection, instance):

--- a/examples/performance/__init__.py
+++ b/examples/performance/__init__.py
@@ -262,7 +262,7 @@ class Profiler(object):
     @classmethod
     def setup(cls, fn):
         if cls._setup is not None:
-            raise ValueError("setup function already set to %s" % cls._setup)
+            raise ValueError("setup function already set to {0!s}".format(cls._setup))
         cls._setup = staticmethod(fn)
         return fn
 
@@ -270,7 +270,7 @@ class Profiler(object):
     def setup_once(cls, fn):
         if cls._setup_once is not None:
             raise ValueError(
-                "setup_once function already set to %s" % cls._setup_once)
+                "setup_once function already set to {0!s}".format(cls._setup_once))
         cls._setup_once = staticmethod(fn)
         return fn
 
@@ -278,14 +278,14 @@ class Profiler(object):
         if self.test:
             tests = [fn for fn in self.tests if fn.__name__ == self.test]
             if not tests:
-                raise ValueError("No such test: %s" % self.test)
+                raise ValueError("No such test: {0!s}".format(self.test))
         else:
             tests = self.tests
 
         if self._setup_once:
             print("Running setup once...")
             self._setup_once(self.dburl, self.echo, self.num)
-        print("Tests to run: %s" % ", ".join([t.__name__ for t in tests]))
+        print("Tests to run: {0!s}".format(", ".join([t.__name__ for t in tests])))
         for test in tests:
             self._run_test(test)
             self.stats[-1].report()
@@ -397,12 +397,12 @@ class TestResult(object):
             self.report_stats()
 
     def _summary(self):
-        summary = "%s : %s (%d iterations)" % (
+        summary = "{0!s} : {1!s} ({2:d} iterations)".format(
             self.test.__name__, self.test.__doc__, self.profile.num)
         if self.total_time:
-            summary += "; total time %f sec" % self.total_time
+            summary += "; total time {0:f} sec".format(self.total_time)
         if self.stats:
-            summary += "; total fn calls %d" % self.stats.total_calls
+            summary += "; total fn calls {0:d}".format(self.stats.total_calls)
         return summary
 
     def report_stats(self):
@@ -418,10 +418,10 @@ class TestResult(object):
             self.stats.print_callers()
 
     def _runsnake(self):
-        filename = "%s.profile" % self.test.__name__
+        filename = "{0!s}.profile".format(self.test.__name__)
         try:
             self.stats.dump_stats(filename)
-            os.system("runsnake %s" % filename)
+            os.system("runsnake {0!s}".format(filename))
         finally:
             os.remove(filename)
 

--- a/examples/performance/bulk_inserts.py
+++ b/examples/performance/bulk_inserts.py
@@ -38,8 +38,8 @@ def test_flush_no_pk(n):
     for chunk in range(0, n, 1000):
         session.add_all([
             Customer(
-                name='customer name %d' % i,
-                description='customer description %d' % i)
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i))
             for i in range(chunk, chunk + 1000)
         ])
         session.flush()
@@ -52,8 +52,8 @@ def test_bulk_save_return_pks(n):
     session = Session(bind=engine)
     session.bulk_save_objects([
         Customer(
-            name='customer name %d' % i,
-            description='customer description %d' % i
+            name='customer name {0:d}'.format(i),
+            description='customer description {0:d}'.format(i)
         )
         for i in range(n)
     ], return_defaults=True)
@@ -68,8 +68,8 @@ def test_flush_pk_given(n):
         session.add_all([
             Customer(
                 id=i + 1,
-                name='customer name %d' % i,
-                description='customer description %d' % i)
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i))
             for i in range(chunk, chunk + 1000)
         ])
         session.flush()
@@ -82,8 +82,8 @@ def test_bulk_save(n):
     session = Session(bind=engine)
     session.bulk_save_objects([
         Customer(
-            name='customer name %d' % i,
-            description='customer description %d' % i
+            name='customer name {0:d}'.format(i),
+            description='customer description {0:d}'.format(i)
         )
         for i in range(n)
     ])
@@ -96,8 +96,8 @@ def test_bulk_insert_mappings(n):
     session = Session(bind=engine)
     session.bulk_insert_mappings(Customer, [
         dict(
-            name='customer name %d' % i,
-            description='customer description %d' % i
+            name='customer name {0:d}'.format(i),
+            description='customer description {0:d}'.format(i)
         )
         for i in range(n)
     ])
@@ -112,8 +112,8 @@ def test_core_insert(n):
         Customer.__table__.insert(),
         [
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )
             for i in range(n)
         ])
@@ -132,13 +132,13 @@ def test_dbapi_raw(n):
 
     if compiled.positional:
         args = (
-            ('customer name %d' % i, 'customer description %d' % i)
+            ('customer name {0:d}'.format(i), 'customer description {0:d}'.format(i))
             for i in range(n))
     else:
         args = (
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )
             for i in range(n)
         )

--- a/examples/performance/bulk_updates.py
+++ b/examples/performance/bulk_updates.py
@@ -34,8 +34,8 @@ def setup_database(dburl, echo, num):
     for chunk in range(0, num, 10000):
         s.bulk_insert_mappings(Customer, [
             {
-                'name': 'customer name %d' % i,
-                'description': 'customer description %d' % i
+                'name': 'customer name {0:d}'.format(i),
+                'description': 'customer description {0:d}'.format(i)
             } for i in range(chunk, chunk + 10000)
         ])
     s.commit()

--- a/examples/performance/large_resultsets.py
+++ b/examples/performance/large_resultsets.py
@@ -46,8 +46,8 @@ def setup_database(dburl, echo, num):
             Customer.__table__.insert(),
             params=[
                 {
-                    'name': 'customer name %d' % i,
-                    'description': 'customer description %d' % i
+                    'name': 'customer name {0:d}'.format(i),
+                    'description': 'customer description {0:d}'.format(i)
                 } for i in range(chunk, chunk + 10000)])
     s.commit()
 

--- a/examples/performance/short_selects.py
+++ b/examples/performance/short_selects.py
@@ -41,7 +41,7 @@ def setup_database(dburl, echo, num):
     sess = Session(engine)
     sess.add_all([
         Customer(
-            id=i, name='c%d' % i, description="c%d" % i,
+            id=i, name='c{0:d}'.format(i), description="c{0:d}".format(i),
             q=i * 10,
             p=i * 20,
             x=i * 30,

--- a/examples/performance/single_inserts.py
+++ b/examples/performance/single_inserts.py
@@ -42,8 +42,8 @@ def test_orm_commit(n):
         session = Session(bind=engine)
         session.add(
             Customer(
-                name='customer name %d' % i,
-                description='customer description %d' % i)
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i))
         )
         session.commit()
 
@@ -56,8 +56,8 @@ def test_bulk_save(n):
         session = Session(bind=engine)
         session.bulk_save_objects([
             Customer(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )])
         session.commit()
 
@@ -70,8 +70,8 @@ def test_bulk_insert_dictionaries(n):
         session = Session(bind=engine)
         session.bulk_insert_mappings(Customer, [
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )])
         session.commit()
 
@@ -85,8 +85,8 @@ def test_core(n):
             conn.execute(
                 Customer.__table__.insert(),
                 dict(
-                    name='customer name %d' % i,
-                    description='customer description %d' % i
+                    name='customer name {0:d}'.format(i),
+                    description='customer description {0:d}'.format(i)
                 )
             )
 
@@ -102,8 +102,8 @@ def test_core_query_caching(n):
             conn.execution_options(compiled_cache=cache).execute(
                 ins,
                 dict(
-                    name='customer name %d' % i,
-                    description='customer description %d' % i
+                    name='customer name {0:d}'.format(i),
+                    description='customer description {0:d}'.format(i)
                 )
             )
 
@@ -130,13 +130,13 @@ def _test_dbapi_raw(n, connect):
 
     if compiled.positional:
         args = (
-            ('customer name %d' % i, 'customer description %d' % i)
+            ('customer name {0:d}'.format(i), 'customer description {0:d}'.format(i))
             for i in range(n))
     else:
         args = (
             dict(
-                name='customer name %d' % i,
-                description='customer description %d' % i
+                name='customer name {0:d}'.format(i),
+                description='customer description {0:d}'.format(i)
             )
             for i in range(n)
         )

--- a/examples/postgis/postgis.py
+++ b/examples/postgis/postgis.py
@@ -12,7 +12,7 @@ class GisElement(object):
         return self.desc
 
     def __repr__(self):
-        return "<%s at 0x%x; %r>" % (self.__class__.__name__,
+        return "<{0!s} at 0x{1:x}; {2!r}>".format(self.__class__.__name__,
                                     id(self), self.desc)
 
 class BinaryGisElement(GisElement, expression.Function):

--- a/examples/versioned_history/history_meta.py
+++ b/examples/versioned_history/history_meta.py
@@ -128,7 +128,7 @@ def _history_mapper(local_mapper):
 
     else:
         bases = local_mapper.base_mapper.class_.__bases__
-    versioned_cls = type.__new__(type, "%sHistory" % cls.__name__, bases, {})
+    versioned_cls = type.__new__(type, "{0!s}History".format(cls.__name__), bases, {})
 
     m = mapper(
         versioned_cls,

--- a/examples/vertical/dictlike-polymorphic.py
+++ b/examples/vertical/dictlike-polymorphic.py
@@ -76,7 +76,7 @@ class PolymorphicVerticalProperty(object):
             pairs = set(self.cls.type_map.values())
             whens = [
                 (
-                    literal_column("'%s'" % discriminator),
+                    literal_column("'{0!s}'".format(discriminator)),
                     cast(getattr(self.cls, attribute), String)
                 ) for attribute, discriminator in pairs
                 if attribute is not None
@@ -88,7 +88,7 @@ class PolymorphicVerticalProperty(object):
             return self._case() != cast(other, String)
 
     def __repr__(self):
-        return '<%s %r=%r>' % (self.__class__.__name__, self.key, self.value)
+        return '<{0!s} {1!r}={2!r}>'.format(self.__class__.__name__, self.key, self.value)
 
 @event.listens_for(PolymorphicVerticalProperty, "mapper_configured", propagate=True)
 def on_new_class(mapper, cls_):
@@ -153,7 +153,7 @@ if __name__ == '__main__':
             self.name = name
 
         def __repr__(self):
-            return "Animal(%r)" % self.name
+            return "Animal({0!r})".format(self.name)
 
         @classmethod
         def with_characteristic(self, key, value):

--- a/examples/vertical/dictlike.py
+++ b/examples/vertical/dictlike.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
             self.name = name
 
         def __repr__(self):
-            return "Animal(%r)" % self.name
+            return "Animal({0!r})".format(self.name)
 
         @classmethod
         def with_characteristic(self, key, value):

--- a/lib/sqlalchemy/connectors/pyodbc.py
+++ b/lib/sqlalchemy/connectors/pyodbc.py
@@ -68,12 +68,12 @@ class PyODBCConnector(Connector):
             dsn_connection = 'dsn' in keys or \
                 ('host' in keys and 'database' not in keys)
             if dsn_connection:
-                connectors = ['dsn=%s' % (keys.pop('host', '') or
-                                          keys.pop('dsn', ''))]
+                connectors = ['dsn={0!s}'.format((keys.pop('host', '') or
+                                          keys.pop('dsn', '')))]
             else:
                 port = ''
                 if 'port' in keys and 'port' not in query:
-                    port = ',%d' % int(keys.pop('port'))
+                    port = ',{0:d}'.format(int(keys.pop('port')))
 
                 connectors = []
                 driver = keys.pop('driver', self.pyodbc_driver_name)
@@ -83,18 +83,18 @@ class PyODBCConnector(Connector):
                         "this is expected by PyODBC when using "
                         "DSN-less connections")
                 else:
-                    connectors.append("DRIVER={%s}" % driver)
+                    connectors.append("DRIVER={{{0!s}}}".format(driver))
 
                 connectors.extend(
                     [
-                        'Server=%s%s' % (keys.pop('host', ''), port),
-                        'Database=%s' % keys.pop('database', '')
+                        'Server={0!s}{1!s}'.format(keys.pop('host', ''), port),
+                        'Database={0!s}'.format(keys.pop('database', ''))
                     ])
 
             user = keys.pop("user", None)
             if user:
-                connectors.append("UID=%s" % user)
-                connectors.append("PWD=%s" % keys.pop('password', ''))
+                connectors.append("UID={0!s}".format(user))
+                connectors.append("PWD={0!s}".format(keys.pop('password', '')))
             else:
                 connectors.append("Trusted_Connection=Yes")
 
@@ -103,10 +103,10 @@ class PyODBCConnector(Connector):
             # client encoding.  This should obviously be set to 'No' if
             # you query a cp1253 encoded database from a latin1 client...
             if 'odbc_autotranslate' in keys:
-                connectors.append("AutoTranslate=%s" %
-                                  keys.pop("odbc_autotranslate"))
+                connectors.append("AutoTranslate={0!s}".format(
+                                  keys.pop("odbc_autotranslate")))
 
-            connectors.extend(['%s=%s' % (k, v) for k, v in keys.items()])
+            connectors.extend(['{0!s}={1!s}'.format(k, v) for k, v in keys.items()])
         return [[";".join(connectors)], connect_args]
 
     def is_disconnect(self, e, connection, cursor):

--- a/lib/sqlalchemy/connectors/zxJDBC.py
+++ b/lib/sqlalchemy/connectors/zxJDBC.py
@@ -34,9 +34,9 @@ class ZxJDBCConnector(Connector):
 
     def _create_jdbc_url(self, url):
         """Create a JDBC url from a :class:`~sqlalchemy.engine.url.URL`"""
-        return 'jdbc:%s://%s%s/%s' % (self.jdbc_db_name, url.host,
+        return 'jdbc:{0!s}://{1!s}{2!s}/{3!s}'.format(self.jdbc_db_name, url.host,
                                       url.port is not None
-                                      and ':%s' % url.port or '',
+                                      and ':{0!s}'.format(url.port) or '',
                                       url.database)
 
     def create_connect_args(self, url):

--- a/lib/sqlalchemy/dialects/__init__.py
+++ b/lib/sqlalchemy/dialects/__init__.py
@@ -40,7 +40,7 @@ def _auto_fn(name):
         )
         dialect = translated
     try:
-        module = __import__('sqlalchemy.dialects.%s' % (dialect, )).dialects
+        module = __import__('sqlalchemy.dialects.{0!s}'.format(dialect )).dialects
     except ImportError:
         return None
 

--- a/lib/sqlalchemy/dialects/firebird/base.py
+++ b/lib/sqlalchemy/dialects/firebird/base.py
@@ -197,7 +197,7 @@ class FBTypeCompiler(compiler.GenericTypeCompiler):
         if charset is None:
             return basic
         else:
-            return '%s CHARACTER SET %s' % (basic, charset)
+            return '{0!s} CHARACTER SET {1!s}'.format(basic, charset)
 
     def visit_CHAR(self, type_, **kw):
         basic = super(FBTypeCompiler, self).visit_CHAR(type_, **kw)
@@ -206,8 +206,8 @@ class FBTypeCompiler(compiler.GenericTypeCompiler):
     def visit_VARCHAR(self, type_, **kw):
         if not type_.length:
             raise exc.CompileError(
-                "VARCHAR requires a length on dialect %s" %
-                self.dialect.name)
+                "VARCHAR requires a length on dialect {0!s}".format(
+                self.dialect.name))
         basic = super(FBTypeCompiler, self).visit_VARCHAR(type_, **kw)
         return self._extend_string(type_, basic)
 
@@ -227,17 +227,17 @@ class FBCompiler(sql.compiler.SQLCompiler):
         return "CURRENT_TIMESTAMP"
 
     def visit_startswith_op_binary(self, binary, operator, **kw):
-        return '%s STARTING WITH %s' % (
+        return '{0!s} STARTING WITH {1!s}'.format(
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw))
 
     def visit_notstartswith_op_binary(self, binary, operator, **kw):
-        return '%s NOT STARTING WITH %s' % (
+        return '{0!s} NOT STARTING WITH {1!s}'.format(
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw))
 
     def visit_mod_binary(self, binary, operator, **kw):
-        return "mod(%s, %s)" % (
+        return "mod({0!s}, {1!s})".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw))
 
@@ -265,9 +265,9 @@ class FBCompiler(sql.compiler.SQLCompiler):
         start = self.process(func.clauses.clauses[1])
         if len(func.clauses.clauses) > 2:
             length = self.process(func.clauses.clauses[2])
-            return "SUBSTRING(%s FROM %s FOR %s)" % (s, start, length)
+            return "SUBSTRING({0!s} FROM {1!s} FOR {2!s})".format(s, start, length)
         else:
-            return "SUBSTRING(%s FROM %s)" % (s, start)
+            return "SUBSTRING({0!s} FROM {1!s})".format(s, start)
 
     def visit_length_func(self, function, **kw):
         if self.dialect._version_two:
@@ -291,7 +291,7 @@ class FBCompiler(sql.compiler.SQLCompiler):
         return " FROM rdb$database"
 
     def visit_sequence(self, seq):
-        return "gen_id(%s, 1)" % self.preparer.format_sequence(seq)
+        return "gen_id({0!s}, 1)".format(self.preparer.format_sequence(seq))
 
     def get_select_precolumns(self, select, **kw):
         """Called when building a ``SELECT`` statement, position is just
@@ -301,9 +301,9 @@ class FBCompiler(sql.compiler.SQLCompiler):
 
         result = ""
         if select._limit_clause is not None:
-            result += "FIRST %s " % self.process(select._limit_clause, **kw)
+            result += "FIRST {0!s} ".format(self.process(select._limit_clause, **kw))
         if select._offset_clause is not None:
-            result += "SKIP %s " % self.process(select._offset_clause, **kw)
+            result += "SKIP {0!s} ".format(self.process(select._offset_clause, **kw))
         if select._distinct:
             result += "DISTINCT "
         return result
@@ -338,21 +338,21 @@ class FBDDLCompiler(sql.compiler.DDLCompiler):
                 "Firebird SEQUENCE doesn't support INCREMENT BY")
 
         if self.dialect._version_two:
-            return "CREATE SEQUENCE %s" % \
-                self.preparer.format_sequence(create.element)
+            return "CREATE SEQUENCE {0!s}".format( \
+                self.preparer.format_sequence(create.element))
         else:
-            return "CREATE GENERATOR %s" % \
-                self.preparer.format_sequence(create.element)
+            return "CREATE GENERATOR {0!s}".format( \
+                self.preparer.format_sequence(create.element))
 
     def visit_drop_sequence(self, drop):
         """Generate a ``DROP GENERATOR`` statement for the sequence."""
 
         if self.dialect._version_two:
-            return "DROP SEQUENCE %s" % \
-                self.preparer.format_sequence(drop.element)
+            return "DROP SEQUENCE {0!s}".format( \
+                self.preparer.format_sequence(drop.element))
         else:
-            return "DROP GENERATOR %s" % \
-                self.preparer.format_sequence(drop.element)
+            return "DROP GENERATOR {0!s}".format( \
+                self.preparer.format_sequence(drop.element))
 
 
 class FBIdentifierPreparer(sql.compiler.IdentifierPreparer):
@@ -371,8 +371,8 @@ class FBExecutionContext(default.DefaultExecutionContext):
         """Get the next value from the sequence using ``gen_id()``."""
 
         return self._execute_scalar(
-            "SELECT gen_id(%s, 1) FROM rdb$database" %
-            self.dialect.identifier_preparer.format_sequence(seq),
+            "SELECT gen_id({0!s}, 1) FROM rdb$database".format(
+            self.dialect.identifier_preparer.format_sequence(seq)),
             type_
         )
 
@@ -609,8 +609,7 @@ class FBDialect(default.DefaultDialect):
             colspec = row['ftype'].rstrip()
             coltype = self.ischema_names.get(colspec)
             if coltype is None:
-                util.warn("Did not recognize type '%s' of column '%s'" %
-                          (colspec, name))
+                util.warn("Did not recognize type '{0!s}' of column '{1!s}'".format(colspec, name))
                 coltype = sqltypes.NULLTYPE
             elif issubclass(coltype, Integer) and row['fprec'] != 0:
                 coltype = NUMERIC(
@@ -637,8 +636,8 @@ class FBDialect(default.DefaultDialect):
                 # (see also http://tracker.firebirdsql.org/browse/CORE-356)
                 defexpr = row['fdefault'].lstrip()
                 assert defexpr[:8].rstrip().upper() == \
-                    'DEFAULT', "Unrecognized default value: %s" % \
-                    defexpr
+                    'DEFAULT', "Unrecognized default value: {0!s}".format( \
+                    defexpr)
                 defvalue = defexpr[8:].strip()
                 if defvalue == 'NULL':
                     # Redundant

--- a/lib/sqlalchemy/dialects/firebird/fdb.py
+++ b/lib/sqlalchemy/dialects/firebird/fdb.py
@@ -87,7 +87,7 @@ class FBDialect_fdb(FBDialect_kinterbasdb):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if opts.get('port'):
-            opts['host'] = "%s/%s" % (opts['host'], opts['port'])
+            opts['host'] = "{0!s}/{1!s}".format(opts['host'], opts['port'])
             del opts['port']
         opts.update(url.query)
 

--- a/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
+++ b/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
@@ -118,7 +118,7 @@ class FBDialect_kinterbasdb(FBDialect):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if opts.get('port'):
-            opts['host'] = "%s/%s" % (opts['host'], opts['port'])
+            opts['host'] = "{0!s}/{1!s}".format(opts['host'], opts['port'])
             del opts['port']
         opts.update(url.query)
 
@@ -163,7 +163,7 @@ class FBDialect_kinterbasdb(FBDialect):
             '\w+-V(\d+)\.(\d+)\.(\d+)\.(\d+)( \w+ (\d+)\.(\d+))?', version)
         if not m:
             raise AssertionError(
-                "Could not determine version from string '%s'" % version)
+                "Could not determine version from string '{0!s}'".format(version))
 
         if m.group(5) != None:
             return tuple([int(x) for x in m.group(6, 7, 4)] + ['firebird'])

--- a/lib/sqlalchemy/dialects/mssql/adodbapi.py
+++ b/lib/sqlalchemy/dialects/mssql/adodbapi.py
@@ -60,15 +60,14 @@ class MSDialect_adodbapi(MSDialect):
 
         connectors = ["Provider=SQLOLEDB"]
         if 'port' in keys:
-            connectors.append("Data Source=%s, %s" %
-                              (keys.get("host"), keys.get("port")))
+            connectors.append("Data Source={0!s}, {1!s}".format(keys.get("host"), keys.get("port")))
         else:
-            connectors.append("Data Source=%s" % keys.get("host"))
-        connectors.append("Initial Catalog=%s" % keys.get("database"))
+            connectors.append("Data Source={0!s}".format(keys.get("host")))
+        connectors.append("Initial Catalog={0!s}".format(keys.get("database")))
         user = keys.get("user")
         if user:
-            connectors.append("User Id=%s" % user)
-            connectors.append("Password=%s" % keys.get("password", ""))
+            connectors.append("User Id={0!s}".format(user))
+            connectors.append("Password={0!s}".format(keys.get("password", "")))
         else:
             connectors.append("Integrated Security=SSPI")
         return [[";".join(connectors)], {}]

--- a/lib/sqlalchemy/dialects/mssql/base.py
+++ b/lib/sqlalchemy/dialects/mssql/base.py
@@ -646,7 +646,7 @@ class _MSDate(sqltypes.Date):
                 m = self._reg.match(value)
                 if not m:
                     raise ValueError(
-                        "could not parse %r as a date value" % (value, ))
+                        "could not parse {0!r} as a date value".format(value ))
                 return datetime.date(*[
                     int(x or 0)
                     for x in m.groups()
@@ -684,7 +684,7 @@ class TIME(sqltypes.TIME):
                 m = self._reg.match(value)
                 if not m:
                     raise ValueError(
-                        "could not parse %r as a time value" % (value, ))
+                        "could not parse {0!r} as a time value".format(value ))
                 return datetime.time(*[
                     int(x or 0)
                     for x in m.groups()])
@@ -853,7 +853,7 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
         """
 
         if getattr(type_, 'collation', None):
-            collation = 'COLLATE %s' % type_.collation
+            collation = 'COLLATE {0!s}'.format(type_.collation)
         else:
             collation = None
 
@@ -861,7 +861,7 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
             length = type_.length
 
         if length:
-            spec = spec + "(%s)" % length
+            spec = spec + "({0!s})".format(length)
 
         return ' '.join([c for c in (spec, collation)
                          if c is not None])
@@ -871,28 +871,28 @@ class MSTypeCompiler(compiler.GenericTypeCompiler):
         if precision is None:
             return "FLOAT"
         else:
-            return "FLOAT(%(precision)s)" % {'precision': precision}
+            return "FLOAT({precision!s})".format(**{'precision': precision})
 
     def visit_TINYINT(self, type_, **kw):
         return "TINYINT"
 
     def visit_DATETIMEOFFSET(self, type_, **kw):
         if type_.precision is not None:
-            return "DATETIMEOFFSET(%s)" % type_.precision
+            return "DATETIMEOFFSET({0!s})".format(type_.precision)
         else:
             return "DATETIMEOFFSET"
 
     def visit_TIME(self, type_, **kw):
         precision = getattr(type_, 'precision', None)
         if precision is not None:
-            return "TIME(%s)" % precision
+            return "TIME({0!s})".format(precision)
         else:
             return "TIME"
 
     def visit_DATETIME2(self, type_, **kw):
         precision = getattr(type_, 'precision', None)
         if precision is not None:
-            return "DATETIME2(%s)" % precision
+            return "DATETIME2({0!s})".format(precision)
         else:
             return "DATETIME2"
 
@@ -1029,8 +1029,8 @@ class MSExecutionContext(default.DefaultExecutionContext):
                 self.root_connection._cursor_execute(
                     self.cursor,
                     self._opt_encode(
-                        "SET IDENTITY_INSERT %s ON" %
-                        self.dialect.identifier_preparer.format_table(tbl)),
+                        "SET IDENTITY_INSERT {0!s} ON".format(
+                        self.dialect.identifier_preparer.format_table(tbl))),
                     (),
                     self)
 
@@ -1060,9 +1060,9 @@ class MSExecutionContext(default.DefaultExecutionContext):
             conn._cursor_execute(
                 self.cursor,
                 self._opt_encode(
-                    "SET IDENTITY_INSERT %s OFF" %
+                    "SET IDENTITY_INSERT {0!s} OFF".format(
                     self.dialect.identifier_preparer. format_table(
-                        self.compiled.statement.table)),
+                        self.compiled.statement.table))),
                 (),
                 self)
 
@@ -1074,9 +1074,9 @@ class MSExecutionContext(default.DefaultExecutionContext):
             try:
                 self.cursor.execute(
                     self._opt_encode(
-                        "SET IDENTITY_INSERT %s OFF" %
+                        "SET IDENTITY_INSERT {0!s} OFF".format(
                         self.dialect.identifier_preparer. format_table(
-                            self.compiled.statement.table)))
+                            self.compiled.statement.table))))
             except Exception:
                 pass
 
@@ -1119,14 +1119,13 @@ class MSSQLCompiler(compiler.SQLCompiler):
         return "GETDATE()"
 
     def visit_length_func(self, fn, **kw):
-        return "LEN%s" % self.function_argspec(fn, **kw)
+        return "LEN{0!s}".format(self.function_argspec(fn, **kw))
 
     def visit_char_length_func(self, fn, **kw):
-        return "LEN%s" % self.function_argspec(fn, **kw)
+        return "LEN{0!s}".format(self.function_argspec(fn, **kw))
 
     def visit_concat_op_binary(self, binary, operator, **kw):
-        return "%s + %s" % \
-            (self.process(binary.left, **kw),
+        return "{0!s} + {1!s}".format(self.process(binary.left, **kw),
              self.process(binary.right, **kw))
 
     def visit_true(self, expr, **kw):
@@ -1136,7 +1135,7 @@ class MSSQLCompiler(compiler.SQLCompiler):
         return '0'
 
     def visit_match_op_binary(self, binary, operator, **kw):
-        return "CONTAINS (%s, %s)" % (
+        return "CONTAINS ({0!s}, {1!s})".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw))
 
@@ -1151,7 +1150,7 @@ class MSSQLCompiler(compiler.SQLCompiler):
             # ODBC drivers and possibly others
             # don't support bind params in the SELECT clause on SQL Server.
             # so have to use literal here.
-            s += "TOP %d " % select._limit
+            s += "TOP {0:d} ".format(select._limit)
 
         if s:
             return s
@@ -1271,16 +1270,14 @@ class MSSQLCompiler(compiler.SQLCompiler):
 
     def visit_extract(self, extract, **kw):
         field = self.extract_map.get(extract.field, extract.field)
-        return 'DATEPART(%s, %s)' % \
-            (field, self.process(extract.expr, **kw))
+        return 'DATEPART({0!s}, {1!s})'.format(field, self.process(extract.expr, **kw))
 
     def visit_savepoint(self, savepoint_stmt):
-        return "SAVE TRANSACTION %s" % \
-            self.preparer.format_savepoint(savepoint_stmt)
+        return "SAVE TRANSACTION {0!s}".format( \
+            self.preparer.format_savepoint(savepoint_stmt))
 
     def visit_rollback_to_savepoint(self, savepoint_stmt):
-        return ("ROLLBACK TRANSACTION %s"
-                % self.preparer.format_savepoint(savepoint_stmt))
+        return ("ROLLBACK TRANSACTION {0!s}".format(self.preparer.format_savepoint(savepoint_stmt)))
 
     def visit_binary(self, binary, **kwargs):
         """Move bind parameters to the right-hand side of an operator, where
@@ -1374,14 +1371,14 @@ class MSSQLStrictCompiler(MSSQLCompiler):
 
     def visit_in_op_binary(self, binary, operator, **kw):
         kw['literal_binds'] = True
-        return "%s IN %s" % (
+        return "{0!s} IN {1!s}".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
 
     def visit_notin_op_binary(self, binary, operator, **kw):
         kw['literal_binds'] = True
-        return "%s NOT IN %s" % (
+        return "{0!s} NOT IN {1!s}".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
@@ -1435,7 +1432,7 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 start = column.default.start or 1
 
-            colspec += " IDENTITY(%s,%s)" % (start,
+            colspec += " IDENTITY({0!s},{1!s})".format(start,
                                              column.default.increment or 1)
         elif column is column.table._autoincrement_column:
             colspec += " IDENTITY(1,1)"
@@ -1462,8 +1459,7 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 text += "NONCLUSTERED "
 
-        text += "INDEX %s ON %s (%s)" \
-            % (
+        text += "INDEX {0!s} ON {1!s} ({2!s})".format(
                 self._prepared_index_name(index,
                                           include_schema=include_schema),
                 preparer.format_table(index.table),
@@ -1482,14 +1478,13 @@ class MSDDLCompiler(compiler.DDLCompiler):
                           index.dialect_options['mssql']['include']
                           ]
 
-            text += " INCLUDE (%s)" \
-                % ', '.join([preparer.quote(c.name)
-                             for c in inclusions])
+            text += " INCLUDE ({0!s})".format(', '.join([preparer.quote(c.name)
+                             for c in inclusions]))
 
         return text
 
     def visit_drop_index(self, drop):
-        return "\nDROP INDEX %s ON %s" % (
+        return "\nDROP INDEX {0!s} ON {1!s}".format(
             self._prepared_index_name(drop.element, include_schema=False),
             self.preparer.format_table(drop.element.table)
         )
@@ -1499,8 +1494,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             return ''
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                    self.preparer.format_constraint(constraint)
+            text += "CONSTRAINT {0!s} ".format( \
+                    self.preparer.format_constraint(constraint))
         text += "PRIMARY KEY "
 
         clustered = constraint.dialect_options['mssql']['clustered']
@@ -1510,8 +1505,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 text += "NONCLUSTERED "
 
-        text += "(%s)" % ', '.join(self.preparer.quote(c.name)
-                                   for c in constraint)
+        text += "({0!s})".format(', '.join(self.preparer.quote(c.name)
+                                   for c in constraint))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -1520,8 +1515,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             return ''
         text = ""
         if constraint.name is not None:
-            text += "CONSTRAINT %s " % \
-                    self.preparer.format_constraint(constraint)
+            text += "CONSTRAINT {0!s} ".format( \
+                    self.preparer.format_constraint(constraint))
         text += "UNIQUE "
 
         clustered = constraint.dialect_options['mssql']['clustered']
@@ -1531,8 +1526,8 @@ class MSDDLCompiler(compiler.DDLCompiler):
             else:
                 text += "NONCLUSTERED "
 
-        text += "(%s)" % ', '.join(self.preparer.quote(c.name)
-                                   for c in constraint)
+        text += "({0!s})".format(', '.join(self.preparer.quote(c.name)
+                                   for c in constraint))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -1572,12 +1567,12 @@ def _db_plus_owner(fn):
 def _switch_db(dbname, connection, fn, *arg, **kw):
     if dbname:
         current_db = connection.scalar("select db_name()")
-        connection.execute("use %s" % dbname)
+        connection.execute("use {0!s}".format(dbname))
     try:
         return fn(*arg, **kw)
     finally:
         if dbname:
-            connection.execute("use %s" % current_db)
+            connection.execute("use {0!s}".format(current_db))
 
 
 def _owner_plus_db(dialect, schema):
@@ -1678,7 +1673,7 @@ class MSDialect(default.DefaultDialect):
             )
         cursor = connection.cursor()
         cursor.execute(
-            "SET TRANSACTION ISOLATION LEVEL %s" % level)
+            "SET TRANSACTION ISOLATION LEVEL {0!s}".format(level))
         cursor.close()
 
     def get_isolation_level(self, connection):
@@ -1928,8 +1923,7 @@ class MSDialect(default.DefaultDialect):
 
             if coltype is None:
                 util.warn(
-                    "Did not recognize type '%s' of column '%s'" %
-                    (type, name))
+                    "Did not recognize type '{0!s}' of column '{1!s}'".format(type, name))
                 coltype = sqltypes.NULLTYPE
             else:
                 if issubclass(coltype, sqltypes.Numeric) and \
@@ -1964,15 +1958,14 @@ class MSDialect(default.DefaultDialect):
                 ic = col_name
                 colmap[col_name]['autoincrement'] = True
                 colmap[col_name]['sequence'] = dict(
-                    name='%s_identity' % col_name)
+                    name='{0!s}_identity'.format(col_name))
                 break
         cursor.close()
 
         if ic is not None and self.server_version_info >= MS_2005_VERSION:
-            table_fullname = "%s.%s" % (owner, tablename)
+            table_fullname = "{0!s}.{1!s}".format(owner, tablename)
             cursor = connection.execute(
-                "select ident_seed('%s'), ident_incr('%s')"
-                % (table_fullname, table_fullname)
+                "select ident_seed('{0!s}'), ident_incr('{1!s}')".format(table_fullname, table_fullname)
             )
 
             row = cursor.first()

--- a/lib/sqlalchemy/dialects/mssql/mxodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/mxodbc.py
@@ -61,7 +61,7 @@ class _MSDate_mxodbc(_MSDate):
     def bind_processor(self, dialect):
         def process(value):
             if value is not None:
-                return "%s-%s-%s" % (value.year, value.month, value.day)
+                return "{0!s}-{1!s}-{2!s}".format(value.year, value.month, value.day)
             else:
                 return None
         return process
@@ -71,7 +71,7 @@ class _MSTime_mxodbc(_MSTime):
     def bind_processor(self, dialect):
         def process(value):
             if value is not None:
-                return "%s:%s:%s" % (value.hour, value.minute, value.second)
+                return "{0!s}:{1!s}:{2!s}".format(value.hour, value.minute, value.second)
             else:
                 return None
         return process

--- a/lib/sqlalchemy/dialects/mssql/pymssql.py
+++ b/lib/sqlalchemy/dialects/mssql/pymssql.py
@@ -75,7 +75,7 @@ class MSDialect_pymssql(MSDialect):
         opts.update(url.query)
         port = opts.pop('port', None)
         if port and 'host' in opts:
-            opts['host'] = "%s:%s" % (opts['host'], port)
+            opts['host'] = "{0!s}:{1!s}".format(opts['host'], port)
         return [[], opts]
 
     def is_disconnect(self, e, connection, cursor):

--- a/lib/sqlalchemy/dialects/mssql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mssql/pyodbc.py
@@ -145,7 +145,7 @@ class _ms_numeric_pyodbc(object):
     # as of 2.1.8 this logic is integrated.
 
     def _small_dec_to_string(self, value):
-        return "%s0.%s%s" % (
+        return "{0!s}0.{1!s}{2!s}".format(
             (value < 0 and '-' or ''),
             '0' * (abs(value.adjusted()) - 1),
             "".join([str(nint) for nint in value.as_tuple()[1]]))
@@ -153,20 +153,20 @@ class _ms_numeric_pyodbc(object):
     def _large_dec_to_string(self, value):
         _int = value.as_tuple()[1]
         if 'E' in str(value):
-            result = "%s%s%s" % (
+            result = "{0!s}{1!s}{2!s}".format(
                 (value < 0 and '-' or ''),
                 "".join([str(s) for s in _int]),
                 "0" * (value.adjusted() - (len(_int) - 1)))
         else:
             if (len(_int) - 1) > value.adjusted():
-                result = "%s%s.%s" % (
+                result = "{0!s}{1!s}.{2!s}".format(
                     (value < 0 and '-' or ''),
                     "".join(
                         [str(s) for s in _int][0:value.adjusted() + 1]),
                     "".join(
                         [str(s) for s in _int][value.adjusted() + 1:]))
             else:
-                result = "%s%s" % (
+                result = "{0!s}{1!s}".format(
                     (value < 0 and '-' or ''),
                     "".join(
                         [str(s) for s in _int][0:value.adjusted() + 1]))

--- a/lib/sqlalchemy/dialects/mssql/zxjdbc.py
+++ b/lib/sqlalchemy/dialects/mssql/zxjdbc.py
@@ -51,7 +51,7 @@ class MSExecutionContext_zxjdbc(MSExecutionContext):
         if self._enable_identity_insert:
             table = self.dialect.identifier_preparer.format_table(
                 self.compiled.statement.table)
-            self.cursor.execute("SET IDENTITY_INSERT %s OFF" % table)
+            self.cursor.execute("SET IDENTITY_INSERT {0!s} OFF".format(table))
 
 
 class MSDialect_zxjdbc(ZxJDBCConnector, MSDialect):

--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -753,7 +753,7 @@ class MySQLCompiler(compiler.SQLCompiler):
     extract_map.update({'milliseconds': 'millisecond'})
 
     def visit_random_func(self, fn, **kw):
-        return "rand%s" % self.function_argspec(fn)
+        return "rand{0!s}".format(self.function_argspec(fn))
 
     def visit_utc_timestamp_func(self, fn, **kw):
         return "UTC_TIMESTAMP"
@@ -762,22 +762,21 @@ class MySQLCompiler(compiler.SQLCompiler):
         return "SYSDATE()"
 
     def visit_json_getitem_op_binary(self, binary, operator, **kw):
-        return "JSON_EXTRACT(%s, %s)" % (
+        return "JSON_EXTRACT({0!s}, {1!s})".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw))
 
     def visit_json_path_getitem_op_binary(self, binary, operator, **kw):
-        return "JSON_EXTRACT(%s, %s)" % (
+        return "JSON_EXTRACT({0!s}, {1!s})".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw))
 
     def visit_concat_op_binary(self, binary, operator, **kw):
-        return "concat(%s, %s)" % (self.process(binary.left),
+        return "concat({0!s}, {1!s})".format(self.process(binary.left),
                                    self.process(binary.right))
 
     def visit_match_op_binary(self, binary, operator, **kw):
-        return "MATCH (%s) AGAINST (%s IN BOOLEAN MODE)" % \
-            (self.process(binary.left), self.process(binary.right))
+        return "MATCH ({0!s}) AGAINST ({1!s} IN BOOLEAN MODE)".format(self.process(binary.left), self.process(binary.right))
 
     def get_from_hint_text(self, table, text):
         return text
@@ -827,7 +826,7 @@ class MySQLCompiler(compiler.SQLCompiler):
                 self.dialect.type_compiler.process(cast.typeclause.type))
             return self.process(cast.clause.self_group(), **kw)
 
-        return 'CAST(%s AS %s)' % (self.process(cast.clause, **kw), type_)
+        return 'CAST({0!s} AS {1!s})'.format(self.process(cast.clause, **kw), type_)
 
     def render_literal_value(self, value, type_):
         value = super(MySQLCompiler, self).render_literal_value(value, type_)
@@ -906,21 +905,21 @@ class MySQLCompiler(compiler.SQLCompiler):
                 # but also is consistent with the usage of the upper
                 # bound as part of MySQL's "syntax" for OFFSET with
                 # no LIMIT
-                return ' \n LIMIT %s, %s' % (
+                return ' \n LIMIT {0!s}, {1!s}'.format(
                     self.process(offset_clause, **kw),
                     "18446744073709551615")
             else:
-                return ' \n LIMIT %s, %s' % (
+                return ' \n LIMIT {0!s}, {1!s}'.format(
                     self.process(offset_clause, **kw),
                     self.process(limit_clause, **kw))
         else:
             # No offset provided, so just use the limit
-            return ' \n LIMIT %s' % (self.process(limit_clause, **kw),)
+            return ' \n LIMIT {0!s}'.format(self.process(limit_clause, **kw))
 
     def update_limit_clause(self, update_stmt):
-        limit = update_stmt.kwargs.get('%s_limit' % self.dialect.name, None)
+        limit = update_stmt.kwargs.get('{0!s}_limit'.format(self.dialect.name), None)
         if limit:
-            return "LIMIT %s" % limit
+            return "LIMIT {0!s}".format(limit)
         else:
             return None
 
@@ -976,7 +975,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                 v
             )
             for k, v in table.kwargs.items()
-            if k.startswith('%s_' % self.dialect.name)
+            if k.startswith('{0!s}_'.format(self.dialect.name))
         )
 
         for opt in topological.sort([
@@ -986,7 +985,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         ], opts):
             arg = opts[opt]
             if opt in _reflection._options_of_type_string:
-                arg = "'%s'" % arg.replace("\\", "\\\\").replace("'", "''")
+                arg = "'{0!s}'".format(arg.replace("\\", "\\\\").replace("'", "''"))
 
             if opt in ('DATA_DIRECTORY', 'INDEX_DIRECTORY',
                        'DEFAULT_CHARACTER_SET', 'CHARACTER_SET',
@@ -1017,7 +1016,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         text = "CREATE "
         if index.unique:
             text += "UNIQUE "
-        text += "INDEX %s ON %s " % (name, table)
+        text += "INDEX {0!s} ON {1!s} ".format(name, table)
 
         length = index.dialect_options['mysql']['length']
         if length is not None:
@@ -1027,11 +1026,11 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                 # mapping specifying the prefix length for each column of the
                 # index
                 columns = ', '.join(
-                    '%s(%d)' % (expr, length[col.name]) if col.name in length
+                    '{0!s}({1:d})'.format(expr, length[col.name]) if col.name in length
                     else
                     (
-                        '%s(%d)' % (expr, length[expr]) if expr in length
-                        else '%s' % expr
+                        '{0!s}({1:d})'.format(expr, length[expr]) if expr in length
+                        else '{0!s}'.format(expr)
                     )
                     for col, expr in zip(index.expressions, columns)
                 )
@@ -1039,16 +1038,16 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
                 # or can be an integer value specifying the same
                 # prefix length for all columns of the index
                 columns = ', '.join(
-                    '%s(%d)' % (col, length)
+                    '{0!s}({1:d})'.format(col, length)
                     for col in columns
                 )
         else:
             columns = ', '.join(columns)
-        text += '(%s)' % columns
+        text += '({0!s})'.format(columns)
 
         using = index.dialect_options['mysql']['using']
         if using is not None:
-            text += " USING %s" % (preparer.quote(using))
+            text += " USING {0!s}".format((preparer.quote(using)))
 
         return text
 
@@ -1057,13 +1056,13 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
             visit_primary_key_constraint(constraint)
         using = constraint.dialect_options['mysql']['using']
         if using:
-            text += " USING %s" % (self.preparer.quote(using))
+            text += " USING {0!s}".format((self.preparer.quote(using)))
         return text
 
     def visit_drop_index(self, drop):
         index = drop.element
 
-        return "\nDROP INDEX %s ON %s" % (
+        return "\nDROP INDEX {0!s} ON {1!s}".format(
             self._prepared_index_name(index,
                                       include_schema=False),
             self.preparer.format_table(index.table))
@@ -1082,8 +1081,7 @@ class MySQLDDLCompiler(compiler.DDLCompiler):
         else:
             qual = ""
             const = self.preparer.format_constraint(constraint)
-        return "ALTER TABLE %s DROP %s%s" % \
-            (self.preparer.format_table(constraint.table),
+        return "ALTER TABLE {0!s} DROP {1!s}{2!s}".format(self.preparer.format_table(constraint.table),
              qual, const)
 
     def define_constraint_match(self, constraint):
@@ -1117,7 +1115,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
             return getattr(type_, name, defaults.get(name))
 
         if attr('charset'):
-            charset = 'CHARACTER SET %s' % attr('charset')
+            charset = 'CHARACTER SET {0!s}'.format(attr('charset'))
         elif attr('ascii'):
             charset = 'ASCII'
         elif attr('unicode'):
@@ -1126,7 +1124,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
             charset = None
 
         if attr('collation'):
-            collation = 'COLLATE %s' % type_.collation
+            collation = 'COLLATE {0!s}'.format(type_.collation)
         elif attr('binary'):
             collation = 'BINARY'
         else:
@@ -1147,42 +1145,42 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
             return self._extend_numeric(type_, "NUMERIC")
         elif type_.scale is None:
             return self._extend_numeric(type_,
-                                        "NUMERIC(%(precision)s)" %
-                                        {'precision': type_.precision})
+                                        "NUMERIC({precision!s})".format(**
+                                        {'precision': type_.precision}))
         else:
             return self._extend_numeric(type_,
-                                        "NUMERIC(%(precision)s, %(scale)s)" %
+                                        "NUMERIC({precision!s}, {scale!s})".format(**
                                         {'precision': type_.precision,
-                                         'scale': type_.scale})
+                                         'scale': type_.scale}))
 
     def visit_DECIMAL(self, type_, **kw):
         if type_.precision is None:
             return self._extend_numeric(type_, "DECIMAL")
         elif type_.scale is None:
             return self._extend_numeric(type_,
-                                        "DECIMAL(%(precision)s)" %
-                                        {'precision': type_.precision})
+                                        "DECIMAL({precision!s})".format(**
+                                        {'precision': type_.precision}))
         else:
             return self._extend_numeric(type_,
-                                        "DECIMAL(%(precision)s, %(scale)s)" %
+                                        "DECIMAL({precision!s}, {scale!s})".format(**
                                         {'precision': type_.precision,
-                                         'scale': type_.scale})
+                                         'scale': type_.scale}))
 
     def visit_DOUBLE(self, type_, **kw):
         if type_.precision is not None and type_.scale is not None:
             return self._extend_numeric(type_,
-                                        "DOUBLE(%(precision)s, %(scale)s)" %
+                                        "DOUBLE({precision!s}, {scale!s})".format(**
                                         {'precision': type_.precision,
-                                         'scale': type_.scale})
+                                         'scale': type_.scale}))
         else:
             return self._extend_numeric(type_, 'DOUBLE')
 
     def visit_REAL(self, type_, **kw):
         if type_.precision is not None and type_.scale is not None:
             return self._extend_numeric(type_,
-                                        "REAL(%(precision)s, %(scale)s)" %
+                                        "REAL({precision!s}, {scale!s})".format(**
                                         {'precision': type_.precision,
-                                         'scale': type_.scale})
+                                         'scale': type_.scale}))
         else:
             return self._extend_numeric(type_, 'REAL')
 
@@ -1191,62 +1189,62 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
                 type_.scale is not None and \
                 type_.precision is not None:
             return self._extend_numeric(
-                type_, "FLOAT(%s, %s)" % (type_.precision, type_.scale))
+                type_, "FLOAT({0!s}, {1!s})".format(type_.precision, type_.scale))
         elif type_.precision is not None:
             return self._extend_numeric(type_,
-                                        "FLOAT(%s)" % (type_.precision,))
+                                        "FLOAT({0!s})".format(type_.precision))
         else:
             return self._extend_numeric(type_, "FLOAT")
 
     def visit_INTEGER(self, type_, **kw):
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
-                type_, "INTEGER(%(display_width)s)" %
-                {'display_width': type_.display_width})
+                type_, "INTEGER({display_width!s})".format(**
+                {'display_width': type_.display_width}))
         else:
             return self._extend_numeric(type_, "INTEGER")
 
     def visit_BIGINT(self, type_, **kw):
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
-                type_, "BIGINT(%(display_width)s)" %
-                {'display_width': type_.display_width})
+                type_, "BIGINT({display_width!s})".format(**
+                {'display_width': type_.display_width}))
         else:
             return self._extend_numeric(type_, "BIGINT")
 
     def visit_MEDIUMINT(self, type_, **kw):
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(
-                type_, "MEDIUMINT(%(display_width)s)" %
-                {'display_width': type_.display_width})
+                type_, "MEDIUMINT({display_width!s})".format(**
+                {'display_width': type_.display_width}))
         else:
             return self._extend_numeric(type_, "MEDIUMINT")
 
     def visit_TINYINT(self, type_, **kw):
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(type_,
-                                        "TINYINT(%s)" % type_.display_width)
+                                        "TINYINT({0!s})".format(type_.display_width))
         else:
             return self._extend_numeric(type_, "TINYINT")
 
     def visit_SMALLINT(self, type_, **kw):
         if self._mysql_type(type_) and type_.display_width is not None:
             return self._extend_numeric(type_,
-                                        "SMALLINT(%(display_width)s)" %
-                                        {'display_width': type_.display_width}
+                                        "SMALLINT({display_width!s})".format(**
+                                        {'display_width': type_.display_width})
                                         )
         else:
             return self._extend_numeric(type_, "SMALLINT")
 
     def visit_BIT(self, type_, **kw):
         if type_.length is not None:
-            return "BIT(%s)" % type_.length
+            return "BIT({0!s})".format(type_.length)
         else:
             return "BIT"
 
     def visit_DATETIME(self, type_, **kw):
         if getattr(type_, 'fsp', None):
-            return "DATETIME(%d)" % type_.fsp
+            return "DATETIME({0:d})".format(type_.fsp)
         else:
             return "DATETIME"
 
@@ -1255,13 +1253,13 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_TIME(self, type_, **kw):
         if getattr(type_, 'fsp', None):
-            return "TIME(%d)" % type_.fsp
+            return "TIME({0:d})".format(type_.fsp)
         else:
             return "TIME"
 
     def visit_TIMESTAMP(self, type_, **kw):
         if getattr(type_, 'fsp', None):
-            return "TIMESTAMP(%d)" % type_.fsp
+            return "TIMESTAMP({0:d})".format(type_.fsp)
         else:
             return "TIMESTAMP"
 
@@ -1269,11 +1267,11 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         if type_.display_width is None:
             return "YEAR"
         else:
-            return "YEAR(%s)" % type_.display_width
+            return "YEAR({0!s})".format(type_.display_width)
 
     def visit_TEXT(self, type_, **kw):
         if type_.length:
-            return self._extend_string(type_, {}, "TEXT(%d)" % type_.length)
+            return self._extend_string(type_, {}, "TEXT({0:d})".format(type_.length))
         else:
             return self._extend_string(type_, {}, "TEXT")
 
@@ -1289,16 +1287,16 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
     def visit_VARCHAR(self, type_, **kw):
         if type_.length:
             return self._extend_string(
-                type_, {}, "VARCHAR(%d)" % type_.length)
+                type_, {}, "VARCHAR({0:d})".format(type_.length))
         else:
             raise exc.CompileError(
-                "VARCHAR requires a length on dialect %s" %
-                self.dialect.name)
+                "VARCHAR requires a length on dialect {0!s}".format(
+                self.dialect.name))
 
     def visit_CHAR(self, type_, **kw):
         if type_.length:
-            return self._extend_string(type_, {}, "CHAR(%(length)s)" %
-                                       {'length': type_.length})
+            return self._extend_string(type_, {}, "CHAR({length!s})".format(**
+                                       {'length': type_.length}))
         else:
             return self._extend_string(type_, {}, "CHAR")
 
@@ -1308,11 +1306,11 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         if type_.length:
             return self._extend_string(
                 type_, {'national': True},
-                "VARCHAR(%(length)s)" % {'length': type_.length})
+                "VARCHAR({length!s})".format(**{'length': type_.length}))
         else:
             raise exc.CompileError(
-                "NVARCHAR requires a length on dialect %s" %
-                self.dialect.name)
+                "NVARCHAR requires a length on dialect {0!s}".format(
+                self.dialect.name))
 
     def visit_NCHAR(self, type_, **kw):
         # We'll actually generate the equiv.
@@ -1320,12 +1318,12 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
         if type_.length:
             return self._extend_string(
                 type_, {'national': True},
-                "CHAR(%(length)s)" % {'length': type_.length})
+                "CHAR({length!s})".format(**{'length': type_.length}))
         else:
             return self._extend_string(type_, {'national': True}, "CHAR")
 
     def visit_VARBINARY(self, type_, **kw):
-        return "VARBINARY(%d)" % type_.length
+        return "VARBINARY({0:d})".format(type_.length)
 
     def visit_JSON(self, type_, **kw):
         return "JSON"
@@ -1341,7 +1339,7 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_BLOB(self, type_, **kw):
         if type_.length:
-            return "BLOB(%d)" % type_.length
+            return "BLOB({0:d})".format(type_.length)
         else:
             return "BLOB"
 
@@ -1357,8 +1355,8 @@ class MySQLTypeCompiler(compiler.GenericTypeCompiler):
     def _visit_enumerated_values(self, name, type_, enumerated_values):
         quoted_enums = []
         for e in enumerated_values:
-            quoted_enums.append("'%s'" % e.replace("'", "''"))
-        return self._extend_string(type_, {}, "%s(%s)" % (
+            quoted_enums.append("'{0!s}'".format(e.replace("'", "''")))
+        return self._extend_string(type_, {}, "{0!s}({1!s})".format(
             name, ",".join(quoted_enums))
         )
 
@@ -1487,7 +1485,7 @@ class MySQLDialect(default.DefaultDialect):
                 (level, self.name, ", ".join(self._isolation_lookup))
             )
         cursor = connection.cursor()
-        cursor.execute("SET SESSION TRANSACTION ISOLATION LEVEL %s" % level)
+        cursor.execute("SET SESSION TRANSACTION ISOLATION LEVEL {0!s}".format(level))
         cursor.execute("COMMIT")
         cursor.close()
 
@@ -1603,7 +1601,7 @@ class MySQLDialect(default.DefaultDialect):
         full_name = '.'.join(self.identifier_preparer._quote_free_identifiers(
             schema, table_name))
 
-        st = "DESCRIBE %s" % full_name
+        st = "DESCRIBE {0!s}".format(full_name)
         rs = None
         try:
             try:
@@ -1656,14 +1654,14 @@ class MySQLDialect(default.DefaultDialect):
         charset = self._connection_charset
         if self.server_version_info < (5, 0, 2):
             rp = connection.execute(
-                "SHOW TABLES FROM %s" %
-                self.identifier_preparer.quote_identifier(current_schema))
+                "SHOW TABLES FROM {0!s}".format(
+                self.identifier_preparer.quote_identifier(current_schema)))
             return [row[0] for
                     row in self._compat_fetchall(rp, charset=charset)]
         else:
             rp = connection.execute(
-                "SHOW FULL TABLES FROM %s" %
-                self.identifier_preparer.quote_identifier(current_schema))
+                "SHOW FULL TABLES FROM {0!s}".format(
+                self.identifier_preparer.quote_identifier(current_schema)))
 
             return [row[0]
                     for row in self._compat_fetchall(rp, charset=charset)
@@ -1679,8 +1677,8 @@ class MySQLDialect(default.DefaultDialect):
             return self.get_table_names(connection, schema)
         charset = self._connection_charset
         rp = connection.execute(
-            "SHOW FULL TABLES FROM %s" %
-            self.identifier_preparer.quote_identifier(schema))
+            "SHOW FULL TABLES FROM {0!s}".format(
+            self.identifier_preparer.quote_identifier(schema)))
         return [row[0]
                 for row in self._compat_fetchall(rp, charset=charset)
                 if row[1] in ('VIEW', 'SYSTEM VIEW')]
@@ -1916,7 +1914,7 @@ class MySQLDialect(default.DefaultDialect):
 
         if full_name is None:
             full_name = self.identifier_preparer.format_table(table)
-        st = "SHOW CREATE TABLE %s" % full_name
+        st = "SHOW CREATE TABLE {0!s}".format(full_name)
 
         rp = None
         try:
@@ -1940,7 +1938,7 @@ class MySQLDialect(default.DefaultDialect):
 
         if full_name is None:
             full_name = self.identifier_preparer.format_table(table)
-        st = "DESCRIBE %s" % full_name
+        st = "DESCRIBE {0!s}".format(full_name)
 
         rp, rows = None, None
         try:

--- a/lib/sqlalchemy/dialects/mysql/json.py
+++ b/lib/sqlalchemy/dialects/mysql/json.py
@@ -63,17 +63,17 @@ class JSONIndexType(_FormatTypeMixin, sqltypes.JSON.JSONIndexType):
 
     def _format_value(self, value):
         if isinstance(value, int):
-            value = "$[%s]" % value
+            value = "$[{0!s}]".format(value)
         else:
-            value = '$."%s"' % value
+            value = '$."{0!s}"'.format(value)
         return value
 
 
 class JSONPathType(_FormatTypeMixin, sqltypes.JSON.JSONPathType):
     def _format_value(self, value):
-        return "$%s" % (
+        return "${0!s}".format((
             "".join([
-                "[%s]" % elem if isinstance(elem, int)
-                else '."%s"' % elem for elem in value
+                "[{0!s}]".format(elem) if isinstance(elem, int)
+                else '."{0!s}"'.format(elem) for elem in value
             ])
-        )
+        ))

--- a/lib/sqlalchemy/dialects/mysql/mysqldb.py
+++ b/lib/sqlalchemy/dialects/mysql/mysqldb.py
@@ -103,8 +103,7 @@ class MySQLDialect_mysqldb(MySQLDialect):
 
         has_utf8_bin = self.server_version_info > (5, ) and \
             connection.scalar(
-                "show collation where %s = 'utf8' and %s = 'utf8_bin'"
-                % (
+                "show collation where {0!s} = 'utf8' and {1!s} = 'utf8_bin'".format(
                     self.identifier_preparer.quote("Charset"),
                     self.identifier_preparer.quote("Collation")
                 ))

--- a/lib/sqlalchemy/dialects/mysql/oursql.py
+++ b/lib/sqlalchemy/dialects/mysql/oursql.py
@@ -86,7 +86,7 @@ class MySQLDialect_oursql(MySQLDialect):
             charset = self._connection_charset
             arg = connection.connection._escape_string(
                 xid.encode(charset)).decode(charset)
-        arg = "'%s'" % arg
+        arg = "'{0!s}'".format(arg)
         connection.execution_options(
             _oursql_plain_query=True).execute(query % arg)
 

--- a/lib/sqlalchemy/dialects/mysql/reflection.py
+++ b/lib/sqlalchemy/dialects/mysql/reflection.py
@@ -53,7 +53,7 @@ class MySQLTableDefinitionParser(object):
             else:
                 type_, spec = self._parse_constraints(line)
                 if type_ is None:
-                    util.warn("Unknown schema content: %r" % line)
+                    util.warn("Unknown schema content: {0!r}".format(line))
                 elif type_ == 'key':
                     state.keys.append(spec)
                 elif type_ == 'constraint':
@@ -135,7 +135,7 @@ class MySQLTableDefinitionParser(object):
             options.pop(nope, None)
 
         for opt, val in options.items():
-            state.table_options['%s_%s' % (self.dialect.name, opt)] = val
+            state.table_options['{0!s}_{1!s}'.format(self.dialect.name, opt)] = val
 
     def _parse_column(self, line, state):
         """Extract column details.
@@ -156,18 +156,17 @@ class MySQLTableDefinitionParser(object):
                 spec = m.groupdict()
                 spec['full'] = False
         if not spec:
-            util.warn("Unknown column definition %r" % line)
+            util.warn("Unknown column definition {0!r}".format(line))
             return
         if not spec['full']:
-            util.warn("Incomplete reflection of column definition %r" % line)
+            util.warn("Incomplete reflection of column definition {0!r}".format(line))
 
         name, type_, args = spec['name'], spec['coltype'], spec['arg']
 
         try:
             col_type = self.dialect.ischema_names[type_]
         except KeyError:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (type_, name))
+            util.warn("Did not recognize type '{0!s}' of column '{1!s}'".format(type_, name))
             col_type = sqltypes.NullType
 
         # Column type positional arguments eg. varchar(32)
@@ -258,14 +257,14 @@ class MySQLTableDefinitionParser(object):
                     line.append(default)
                 else:
                     line.append('DEFAULT')
-                    line.append("'%s'" % default.replace("'", "''"))
+                    line.append("'{0!s}'".format(default.replace("'", "''")))
             if extra:
                 line.append(extra)
 
             buffer.append(' '.join(line))
 
-        return ''.join([('CREATE TABLE %s (\n' %
-                         self.preparer.quote_identifier(table_name)),
+        return ''.join([('CREATE TABLE {0!s} (\n'.format(
+                         self.preparer.quote_identifier(table_name))),
                         ',\n'.join(buffer),
                         '\n) '])
 

--- a/lib/sqlalchemy/dialects/oracle/cx_oracle.py
+++ b/lib/sqlalchemy/dialects/oracle/cx_oracle.py
@@ -317,7 +317,7 @@ class _OracleNumeric(sqltypes.Numeric):
 
         if dialect.supports_native_decimal:
             if self.asdecimal:
-                fstring = "%%.%df" % self._effective_decimal_return_scale
+                fstring = "%.{0:d}f".format(self._effective_decimal_return_scale)
 
                 def to_decimal(value):
                     if value is None:
@@ -488,7 +488,7 @@ class OracleCompiler_cx_oracle(OracleCompiler):
         quote = getattr(name, 'quote', None)
         if quote is True or quote is not False and \
                 self.preparer._bindparam_requires_quotes(name):
-            quoted_name = '"%s"' % name
+            quoted_name = '"{0!s}"'.format(name)
             self._quoted_bind_names[name] = quoted_name
             return OracleCompiler.bindparam_string(self, quoted_name, **kw)
         else:
@@ -637,13 +637,13 @@ class ReturningResultProxy(_result.FullyBufferedResultProxy):
     def _cursor_description(self):
         returning = self.context.compiled.returning
         return [
-            ("ret_%d" % i, None)
+            ("ret_{0:d}".format(i), None)
             for i, col in enumerate(returning)
         ]
 
     def _buffer_rows(self):
         return collections.deque(
-            [tuple(self._returning_params["ret_%d" % i]
+            [tuple(self._returning_params["ret_{0:d}".format(i)]
                    for i, c in enumerate(self._returning_params))]
         )
 
@@ -976,7 +976,7 @@ class OracleDialect_cx_oracle(OracleDialect):
         do_commit_twophase().  its format is unspecified."""
 
         id = random.randint(0, 2 ** 128)
-        return (0x1234, "%032x" % id, "%032x" % 9)
+        return (0x1234, "{0:032x}".format(id), "{0:032x}".format(9))
 
     def do_executemany(self, cursor, statement, parameters, context=None):
         if isinstance(parameters, tuple):

--- a/lib/sqlalchemy/dialects/oracle/zxjdbc.py
+++ b/lib/sqlalchemy/dialects/oracle/zxjdbc.py
@@ -83,7 +83,7 @@ class OracleCompiler_zxjdbc(OracleCompiler):
             self.returning_parameters.append((i + 1, dbtype))
 
             bindparam = sql.bindparam(
-                "ret_%d" % i, value=ReturningParam(dbtype))
+                "ret_{0:d}".format(i), value=ReturningParam(dbtype))
             self.binds[bindparam.key] = bindparam
             binds.append(
                 self.bindparam_string(self._truncate_bindparam(bindparam)))
@@ -107,10 +107,10 @@ class OracleExecutionContext_zxjdbc(OracleExecutionContext):
                     rrs = self.statement.__statement__.getReturnResultSet()
                     next(rrs)
                 except SQLException as sqle:
-                    msg = '%s [SQLCode: %d]' % (
+                    msg = '{0!s} [SQLCode: {1:d}]'.format(
                         sqle.getMessage(), sqle.getErrorCode())
                     if sqle.getSQLState() is not None:
-                        msg += ' [SQLState: %s]' % sqle.getSQLState()
+                        msg += ' [SQLState: {0!s}]'.format(sqle.getSQLState())
                     raise zxJDBC.Error(msg)
                 else:
                     row = tuple(
@@ -178,7 +178,7 @@ class ReturningParam(object):
 
     def __repr__(self):
         kls = self.__class__
-        return '<%s.%s object at 0x%x type=%s>' % (
+        return '<{0!s}.{1!s} object at 0x{2:x} type={3!s}>'.format(
             kls.__module__, kls.__name__, id(self), self.type)
 
 
@@ -224,7 +224,7 @@ class OracleDialect_zxjdbc(ZxJDBCConnector, OracleDialect):
             connection.connection.driverversion >= '10.2'
 
     def _create_jdbc_url(self, url):
-        return 'jdbc:oracle:thin:@%s:%s:%s' % (
+        return 'jdbc:oracle:thin:@{0!s}:{1!s}:{2!s}'.format(
             url.host, url.port or 1521, url.database)
 
     def _get_server_version_info(self, connection):

--- a/lib/sqlalchemy/dialects/postgresql/hstore.py
+++ b/lib/sqlalchemy/dialects/postgresql/hstore.py
@@ -349,7 +349,7 @@ def _parse_error(hstore_str, pos):
     if len(residual) > ctx:
         residual = residual[:-1] + '[...]'
 
-    return "After %r, could not parse residual at position %d: %r" % (
+    return "After {0!r}, could not parse residual at position {1:d}: {2!r}".format(
         parsed_tail, pos, residual)
 
 
@@ -402,12 +402,11 @@ def _serialize_hstore(val):
         if position == 'value' and s is None:
             return 'NULL'
         elif isinstance(s, util.string_types):
-            return '"%s"' % s.replace("\\", "\\\\").replace('"', r'\"')
+            return '"{0!s}"'.format(s.replace("\\", "\\\\").replace('"', r'\"'))
         else:
-            raise ValueError("%r in %s position is not a string." %
-                             (s, position))
+            raise ValueError("{0!r} in {1!s} position is not a string.".format(s, position))
 
-    return ', '.join('%s=>%s' % (esc(k, 'key'), esc(v, 'value'))
+    return ', '.join('{0!s}=>{1!s}'.format(esc(k, 'key'), esc(v, 'value'))
                      for k, v in val.items())
 
 

--- a/lib/sqlalchemy/dialects/postgresql/json.py
+++ b/lib/sqlalchemy/dialects/postgresql/json.py
@@ -54,7 +54,7 @@ class JSONPathType(sqltypes.JSON.JSONPathType):
         def process(value):
             assert isinstance(value, collections.Sequence)
             tokens = [util.text_type(elem)for elem in value]
-            value = "{%s}" % (", ".join(tokens))
+            value = "{{{0!s}}}".format((", ".join(tokens)))
             if super_proc:
                 value = super_proc(value)
             return value
@@ -67,7 +67,7 @@ class JSONPathType(sqltypes.JSON.JSONPathType):
         def process(value):
             assert isinstance(value, collections.Sequence)
             tokens = [util.text_type(elem)for elem in value]
-            value = "{%s}" % (", ".join(tokens))
+            value = "{{{0!s}}}".format((", ".join(tokens)))
             if super_proc:
                 value = super_proc(value)
             return value

--- a/lib/sqlalchemy/dialects/postgresql/pg8000.py
+++ b/lib/sqlalchemy/dialects/postgresql/pg8000.py
@@ -86,7 +86,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # pg8000 returns float natively for 701
@@ -95,7 +95,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGNumericNoBind(_PGNumeric):

--- a/lib/sqlalchemy/dialects/postgresql/psycopg2.py
+++ b/lib/sqlalchemy/dialects/postgresql/psycopg2.py
@@ -349,7 +349,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # pg8000 returns float natively for 701
@@ -358,7 +358,7 @@ class _PGNumeric(sqltypes.Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGEnum(ENUM):
@@ -457,7 +457,7 @@ class PGExecutionContext_psycopg2(PGExecutionContext):
         if is_server_side:
             # use server-side cursors:
             # http://lists.initd.org/pipermail/psycopg/2007-January/005251.html
-            ident = "c_%s_%s" % (hex(id(self))[2:],
+            ident = "c_{0!s}_{1!s}".format(hex(id(self))[2:],
                                  hex(_server_side_id())[2:])
             return self._dbapi_connection.cursor(ident)
         else:

--- a/lib/sqlalchemy/dialects/postgresql/pygresql.py
+++ b/lib/sqlalchemy/dialects/postgresql/pygresql.py
@@ -44,7 +44,7 @@ class _PGNumeric(Numeric):
                 return None
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
         else:
             if coltype in _FLOAT_TYPES:
                 # PyGreSQL returns float natively for 701 (float8)
@@ -53,7 +53,7 @@ class _PGNumeric(Numeric):
                 return processors.to_float
             else:
                 raise exc.InvalidRequestError(
-                    "Unknown PG numeric type: %d" % coltype)
+                    "Unknown PG numeric type: {0:d}".format(coltype))
 
 
 class _PGHStore(HSTORE):
@@ -217,7 +217,7 @@ class PGDialect_pygresql(PGDialect):
     def create_connect_args(self, url):
         opts = url.translate_connect_args(username='user')
         if 'port' in opts:
-            opts['host'] = '%s:%s' % (
+            opts['host'] = '{0!s}:{1!s}'.format(
                 opts.get('host', '').rsplit(':', 1)[0], opts.pop('port'))
         opts.update(url.query)
         return [], opts

--- a/lib/sqlalchemy/dialects/sqlite/base.py
+++ b/lib/sqlalchemy/dialects/sqlite/base.py
@@ -522,7 +522,7 @@ class _DateTimeMixin(object):
         bp = self.bind_processor(dialect)
 
         def process(value):
-            return "'%s'" % bp(value)
+            return "'{0!s}'".format(bp(value))
         return process
 
 
@@ -815,7 +815,7 @@ class SQLiteCompiler(compiler.SQLCompiler):
         return '0'
 
     def visit_char_length_func(self, fn, **kw):
-        return "length%s" % self.function_argspec(fn)
+        return "length{0!s}".format(self.function_argspec(fn))
 
     def visit_cast(self, cast, **kwargs):
         if self.dialect.supports_cast:
@@ -825,13 +825,13 @@ class SQLiteCompiler(compiler.SQLCompiler):
 
     def visit_extract(self, extract, **kw):
         try:
-            return "CAST(STRFTIME('%s', %s) AS INTEGER)" % (
+            return "CAST(STRFTIME('{0!s}', {1!s}) AS INTEGER)".format(
                 self.extract_map[extract.field],
                 self.process(extract.expr, **kw)
             )
         except KeyError:
             raise exc.CompileError(
-                "%s is not a valid extract argument." % extract.field)
+                "{0!s} is not a valid extract argument.".format(extract.field))
 
     def limit_clause(self, select, **kw):
         text = ""
@@ -850,11 +850,11 @@ class SQLiteCompiler(compiler.SQLCompiler):
         return ''
 
     def visit_is_distinct_from_binary(self, binary, operator, **kw):
-        return "%s IS NOT %s" % (self.process(binary.left),
+        return "{0!s} IS NOT {1!s}".format(self.process(binary.left),
                                  self.process(binary.right))
 
     def visit_isnot_distinct_from_binary(self, binary, operator, **kw):
-        return "%s IS %s" % (self.process(binary.left),
+        return "{0!s} IS {1!s}".format(self.process(binary.left),
                              self.process(binary.right))
 
 
@@ -928,8 +928,7 @@ class SQLiteDDLCompiler(compiler.DDLCompiler):
         text = "CREATE "
         if index.unique:
             text += "UNIQUE "
-        text += "INDEX %s ON %s (%s)" \
-            % (
+        text += "INDEX {0!s} ON {1!s} ({2!s})".format(
                 self._prepared_index_name(index,
                                           include_schema=True),
                 preparer.format_table(index.table,
@@ -1110,7 +1109,7 @@ class SQLiteDialect(default.DefaultDialect):
                 (level, self.name, ", ".join(self._isolation_lookup))
             )
         cursor = connection.cursor()
-        cursor.execute("PRAGMA read_uncommitted = %d" % isolation_level)
+        cursor.execute("PRAGMA read_uncommitted = {0:d}".format(isolation_level))
         cursor.close()
 
     def get_isolation_level(self, connection):
@@ -1133,7 +1132,7 @@ class SQLiteDialect(default.DefaultDialect):
         elif value == 1:
             return "READ UNCOMMITTED"
         else:
-            assert False, "Unknown isolation level %s" % value
+            assert False, "Unknown isolation level {0!s}".format(value)
 
     def on_connect(self):
         if self.isolation_level is not None:
@@ -1154,7 +1153,7 @@ class SQLiteDialect(default.DefaultDialect):
     def get_table_names(self, connection, schema=None, **kw):
         if schema is not None:
             qschema = self.identifier_preparer.quote_identifier(schema)
-            master = '%s.sqlite_master' % qschema
+            master = '{0!s}.sqlite_master'.format(qschema)
         else:
             master = "sqlite_master"
         s = ("SELECT name FROM %s "
@@ -1187,7 +1186,7 @@ class SQLiteDialect(default.DefaultDialect):
     def get_view_names(self, connection, schema=None, **kw):
         if schema is not None:
             qschema = self.identifier_preparer.quote_identifier(schema)
-            master = '%s.sqlite_master' % qschema
+            master = '{0!s}.sqlite_master'.format(qschema)
         else:
             master = "sqlite_master"
         s = ("SELECT name FROM %s "
@@ -1200,7 +1199,7 @@ class SQLiteDialect(default.DefaultDialect):
     def get_view_definition(self, connection, view_name, schema=None, **kw):
         if schema is not None:
             qschema = self.identifier_preparer.quote_identifier(schema)
-            master = '%s.sqlite_master' % qschema
+            master = '{0!s}.sqlite_master'.format(qschema)
             s = ("SELECT sql FROM %s WHERE name = '%s'"
                  "AND type='view'") % (master, view_name)
             rs = connection.execute(s)
@@ -1561,11 +1560,11 @@ class SQLiteDialect(default.DefaultDialect):
     def _get_table_pragma(self, connection, pragma, table_name, schema=None):
         quote = self.identifier_preparer.quote_identifier
         if schema is not None:
-            statement = "PRAGMA %s." % quote(schema)
+            statement = "PRAGMA {0!s}.".format(quote(schema))
         else:
             statement = "PRAGMA "
         qtable = quote(table_name)
-        statement = "%s%s(%s)" % (statement, pragma, qtable)
+        statement = "{0!s}{1!s}({2!s})".format(statement, pragma, qtable)
         cursor = connection.execute(statement)
         if not cursor._soft_closed:
             # work around SQLite issue whereby cursor.description

--- a/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlcipher.py
@@ -97,10 +97,10 @@ class SQLiteDialect_pysqlcipher(SQLiteDialect_pysqlite):
 
         conn = super(SQLiteDialect_pysqlcipher, self).\
             connect(*cargs, **cparams)
-        conn.execute('pragma key="%s"' % passphrase)
+        conn.execute('pragma key="{0!s}"'.format(passphrase))
         for prag, value in pragmas.items():
             if value is not None:
-                conn.execute('pragma %s=%s' % (prag, value))
+                conn.execute('pragma {0!s}={1!s}'.format(prag, value))
 
         return conn
 

--- a/lib/sqlalchemy/dialects/sybase/base.py
+++ b/lib/sqlalchemy/dialects/sybase/base.py
@@ -156,10 +156,10 @@ class SybaseTypeCompiler(compiler.GenericTypeCompiler):
         return self.visit_NVARCHAR(type_)
 
     def visit_UNICHAR(self, type_, **kw):
-        return "UNICHAR(%d)" % type_.length
+        return "UNICHAR({0:d})".format(type_.length)
 
     def visit_UNIVARCHAR(self, type_, **kw):
-        return "UNIVARCHAR(%d)" % type_.length
+        return "UNIVARCHAR({0:d})".format(type_.length)
 
     def visit_UNITEXT(self, type_, **kw):
         return "UNITEXT"
@@ -274,8 +274,8 @@ class SybaseExecutionContext(default.DefaultExecutionContext):
 
             if self._enable_identity_insert:
                 self.cursor.execute(
-                    "SET IDENTITY_INSERT %s ON" %
-                    self.dialect.identifier_preparer.format_table(tbl))
+                    "SET IDENTITY_INSERT {0!s} ON".format(
+                    self.dialect.identifier_preparer.format_table(tbl)))
 
         if self.isddl:
             # TODO: to enhance this, we can detect "ddl in tran" on the
@@ -299,9 +299,9 @@ class SybaseExecutionContext(default.DefaultExecutionContext):
 
         if self._enable_identity_insert:
             self.cursor.execute(
-                "SET IDENTITY_INSERT %s OFF" %
+                "SET IDENTITY_INSERT {0!s} OFF".format(
                 self.dialect.identifier_preparer.
-                format_table(self.compiled.statement.table)
+                format_table(self.compiled.statement.table))
             )
 
     def get_lastrowid(self):
@@ -333,7 +333,7 @@ class SybaseSQLCompiler(compiler.SQLCompiler):
                 # s += "FIRST "
             # else:
                 # s += "TOP %s " % (select._limit,)
-            s += "TOP %s " % (limit,)
+            s += "TOP {0!s} ".format(limit)
         offset = select._offset
         if offset:
             raise NotImplementedError("Sybase ASE does not support OFFSET")
@@ -348,7 +348,7 @@ class SybaseSQLCompiler(compiler.SQLCompiler):
 
     def visit_extract(self, extract, **kw):
         field = self.extract_map.get(extract.field, extract.field)
-        return 'DATEPART("%s", %s)' % (
+        return 'DATEPART("{0!s}", {1!s})'.format(
             field, self.process(extract.expr, **kw))
 
     def visit_now_func(self, fn, **kw):
@@ -395,7 +395,7 @@ class SybaseDDLCompiler(compiler.DDLCompiler):
                 colspec += " IDENTITY"
             else:
                 # TODO: need correct syntax for this
-                colspec += " IDENTITY(%s,%s)" % (start, increment)
+                colspec += " IDENTITY({0!s},{1!s})".format(start, increment)
         else:
             default = self.get_column_default_string(column)
             if default is not None:
@@ -411,7 +411,7 @@ class SybaseDDLCompiler(compiler.DDLCompiler):
 
     def visit_drop_index(self, drop):
         index = drop.element
-        return "\nDROP INDEX %s.%s" % (
+        return "\nDROP INDEX {0!s}.{1!s}".format(
             self.preparer.quote_identifier(index.table.name),
             self._prepared_index_name(drop.element,
                                       include_schema=False)
@@ -547,8 +547,7 @@ class SybaseDialect(default.DefaultDialect):
             # if is_array:
             #     coltype = ARRAY(coltype)
         else:
-            util.warn("Did not recognize type '%s' of column '%s'" %
-                      (type_, name))
+            util.warn("Did not recognize type '{0!s}' of column '{1!s}'".format(type_, name))
             coltype = sqltypes.NULLTYPE
 
         if default:
@@ -638,8 +637,8 @@ class SybaseDialect(default.DefaultDialect):
             constrained_columns = []
             referred_columns = []
             for i in range(1, r["count"] + 1):
-                constrained_columns.append(columns[r["fokey%i" % i]])
-                referred_columns.append(reftable_columns[r["refkey%i" % i]])
+                constrained_columns.append(columns[r["fokey{0:d}".format(i)]])
+                referred_columns.append(reftable_columns[r["refkey{0:d}".format(i)]])
 
             fk_info = {
                 "constrained_columns": constrained_columns,
@@ -691,7 +690,7 @@ class SybaseDialect(default.DefaultDialect):
         for r in results:
             column_names = []
             for i in range(1, r["count"]):
-                column_names.append(r["col_%i" % (i,)])
+                column_names.append(r["col_{0:d}".format(i)])
             index_info = {"name": r["name"],
                           "unique": bool(r["unique"]),
                           "column_names": column_names}
@@ -738,7 +737,7 @@ class SybaseDialect(default.DefaultDialect):
         constrained_columns = []
         if pks:
             for i in range(1, pks["count"] + 1):
-                constrained_columns.append(pks["pk_%i" % (i,)])
+                constrained_columns.append(pks["pk_{0:d}".format(i)])
             return {"constrained_columns": constrained_columns,
                     "name": pks["name"]}
         else:

--- a/lib/sqlalchemy/engine/base.py
+++ b/lib/sqlalchemy/engine/base.py
@@ -735,7 +735,7 @@ class Connection(Connectable):
 
         if name is None:
             self.__savepoint_seq += 1
-            name = 'sa_savepoint_%s' % self.__savepoint_seq
+            name = 'sa_savepoint_{0!s}'.format(self.__savepoint_seq)
         if self._still_open_and_connection_is_valid:
             self.engine.dialect.do_savepoint(self, name)
             return name
@@ -1869,7 +1869,7 @@ class Engine(Connectable, log.Identified):
     echo = log.echo_property()
 
     def __repr__(self):
-        return 'Engine(%r)' % self.url
+        return 'Engine({0!r})'.format(self.url)
 
     def dispose(self):
         """Dispose of the connection pool used by this :class:`.Engine`.

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -175,8 +175,8 @@ class DefaultDialect(interfaces.Dialect):
 
         if not getattr(self, 'ported_sqla_06', True):
             util.warn(
-                "The %s dialect is not yet ported to the 0.6 format" %
-                self.name)
+                "The {0!s} dialect is not yet ported to the 0.6 format".format(
+                self.name))
 
         self.convert_unicode = convert_unicode
         self.encoding = encoding
@@ -377,8 +377,7 @@ class DefaultDialect(interfaces.Dialect):
     def validate_identifier(self, ident):
         if len(ident) > self.max_identifier_length:
             raise exc.IdentifierError(
-                "Identifier '%s' exceeds maximum length of %d characters" %
-                (ident, self.max_identifier_length)
+                "Identifier '{0!s}' exceeds maximum length of {1:d} characters".format(ident, self.max_identifier_length)
             )
 
     def connect(self, *cargs, **cparams):
@@ -444,7 +443,7 @@ class DefaultDialect(interfaces.Dialect):
         do_commit_twophase().  Its format is unspecified.
         """
 
-        return "_sa_%032x" % random.randint(0, 2 ** 128)
+        return "_sa_{0:032x}".format(random.randint(0, 2 ** 128))
 
     def do_savepoint(self, connection, name):
         connection.execute(expression.SavepointClause(name))

--- a/lib/sqlalchemy/engine/reflection.py
+++ b/lib/sqlalchemy/engine/reflection.py
@@ -753,8 +753,7 @@ class Inspector(object):
             if include_columns and \
                     not set(columns).issubset(include_columns):
                 util.warn(
-                    "Omitting %s key for (%s), key covers omitted columns." %
-                    (flavor, ', '.join(columns)))
+                    "Omitting {0!s} key for ({1!s}), key covers omitted columns.".format(flavor, ', '.join(columns)))
                 continue
             if duplicates:
                 continue

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -559,8 +559,8 @@ class ResultMetaData(object):
         if result is None:
             if raiseerr:
                 raise exc.NoSuchColumnError(
-                    "Could not locate column in row for column '%s'" %
-                    expression._string_or_unprintable(key))
+                    "Could not locate column in row for column '{0!s}'".format(
+                    expression._string_or_unprintable(key)))
             else:
                 return None
         else:

--- a/lib/sqlalchemy/engine/strategies.py
+++ b/lib/sqlalchemy/engine/strategies.py
@@ -143,7 +143,7 @@ class DefaultEngineStrategy(EngineStrategy):
                 "Invalid argument(s) %s sent to create_engine(), "
                 "using configuration %s/%s/%s.  Please check that the "
                 "keyword arguments are appropriate for this combination "
-                "of components." % (','.join("'%s'" % k for k in kwargs),
+                "of components." % (','.join("'{0!s}'".format(k) for k in kwargs),
                                     dialect.__class__.__name__,
                                     pool.__class__.__name__,
                                     engineclass.__name__))

--- a/lib/sqlalchemy/engine/threadlocal.py
+++ b/lib/sqlalchemy/engine/threadlocal.py
@@ -135,4 +135,4 @@ class TLEngine(base.Engine):
             self._connections.trans = []
 
     def __repr__(self):
-        return 'TLEngine(%s)' % str(self.url)
+        return 'TLEngine({0!s})'.format(str(self.url))

--- a/lib/sqlalchemy/engine/url.py
+++ b/lib/sqlalchemy/engine/url.py
@@ -73,7 +73,7 @@ class URL(object):
             s += "@"
         if self.host is not None:
             if ':' in self.host:
-                s += "[%s]" % self.host
+                s += "[{0!s}]".format(self.host)
             else:
                 s += self.host
         if self.port is not None:
@@ -83,7 +83,7 @@ class URL(object):
         if self.query:
             keys = list(self.query)
             keys.sort()
-            s += '?' + "&".join("%s=%s" % (k, self.query[k]) for k in keys)
+            s += '?' + "&".join("{0!s}={1!s}".format(k, self.query[k]) for k in keys)
         return s
 
     def __str__(self):
@@ -240,11 +240,11 @@ def _parse_rfc1738_args(name):
         return URL(name, **components)
     else:
         raise exc.ArgumentError(
-            "Could not parse rfc1738 URL from string '%s'" % name)
+            "Could not parse rfc1738 URL from string '{0!s}'".format(name))
 
 
 def _rfc_1738_quote(text):
-    return re.sub(r'[:@/]', lambda m: "%%%X" % ord(m.group(0)), text)
+    return re.sub(r'[:@/]', lambda m: "%{0:X}".format(ord(m.group(0))), text)
 
 
 def _rfc_1738_unquote(text):

--- a/lib/sqlalchemy/event/api.py
+++ b/lib/sqlalchemy/event/api.py
@@ -24,8 +24,7 @@ def _event_key(target, identifier, fn):
         if tgt is not None:
             return _EventKey(target, identifier, fn, tgt)
     else:
-        raise exc.InvalidRequestError("No such event '%s' for target '%s'" %
-                                      (identifier, target))
+        raise exc.InvalidRequestError("No such event '{0!s}' for target '{1!s}'".format(identifier, target))
 
 
 def listen(target, identifier, fn, *args, **kw):

--- a/lib/sqlalchemy/event/base.py
+++ b/lib/sqlalchemy/event/base.py
@@ -122,7 +122,7 @@ class _Dispatch(object):
         """
         if '_joined_dispatch_cls' not in self.__class__.__dict__:
             cls = type(
-                "Joined%s" % self.__class__.__name__,
+                "Joined{0!s}".format(self.__class__.__name__),
                 (_JoinedDispatcher, ), {'__slots__': self._event_names}
             )
 
@@ -168,7 +168,7 @@ def _create_dispatcher_class(cls, classname, bases, dict_):
         dispatch_base = _Dispatch
 
     event_names = [k for k in dict_ if _is_event_name(k)]
-    dispatch_cls = type("%sDispatch" % classname,
+    dispatch_cls = type("{0!s}Dispatch".format(classname),
                         (dispatch_base, ), {'__slots__': event_names})
 
     dispatch_cls._event_names = event_names

--- a/lib/sqlalchemy/event/legacy.py
+++ b/lib/sqlalchemy/event/legacy.py
@@ -61,7 +61,7 @@ def _indent(text, indent):
 def _standard_listen_example(dispatch_collection, sample_target, fn):
     example_kw_arg = _indent(
         "\n".join(
-            "%(arg)s = kw['%(arg)s']" % {"arg": arg}
+            "{arg!s} = kw['{arg!s}']".format(**{"arg": arg})
             for arg in dispatch_collection.arg_names[0:2]
         ),
         "    ")
@@ -93,8 +93,8 @@ def _standard_listen_example(dispatch_collection, sample_target, fn):
         )
 
     text %= {
-        "current_since": " (arguments as of %s)" %
-        current_since if current_since else "",
+        "current_since": " (arguments as of {0!s})".format(
+        current_since) if current_since else "",
         "event_name": fn.__name__,
         "has_kw_arguments": ", **kw" if dispatch_collection.has_kw else "",
         "named_event_arguments": ", ".join(dispatch_collection.arg_names),

--- a/lib/sqlalchemy/event/registry.py
+++ b/lib/sqlalchemy/event/registry.py
@@ -208,8 +208,7 @@ class _EventKey(object):
 
         if key not in _key_to_collection:
             raise exc.InvalidRequestError(
-                "No listeners found for event %s / %r / %s " %
-                (self.target, self.identifier, self.fn)
+                "No listeners found for event {0!s} / {1!r} / {2!s} ".format(self.target, self.identifier, self.fn)
             )
         dispatch_reg = _key_to_collection.pop(key)
 

--- a/lib/sqlalchemy/exc.py
+++ b/lib/sqlalchemy/exc.py
@@ -36,7 +36,7 @@ class ObjectNotExecutableError(ArgumentError):
 
     def __init__(self, target):
         super(ObjectNotExecutableError, self).__init__(
-            "Not an executable object: %r" % target
+            "Not an executable object: {0!r}".format(target)
         )
 
 
@@ -74,7 +74,7 @@ class CircularDependencyError(SQLAlchemyError):
     """
     def __init__(self, message, cycles, edges, msg=None):
         if msg is None:
-            message += " (%s)" % ", ".join(repr(s) for s in cycles)
+            message += " ({0!s})".format(", ".join(repr(s) for s in cycles))
         else:
             message = msg
         SQLAlchemyError.__init__(self, message)
@@ -100,8 +100,7 @@ class UnsupportedCompilationError(CompileError):
 
     def __init__(self, compiler, element_type):
         super(UnsupportedCompilationError, self).__init__(
-            "Compiler %r can't render element of type %s" %
-            (compiler, element_type))
+            "Compiler {0!r} can't render element of type {1!s}".format(compiler, element_type))
 
 
 class IdentifierError(SQLAlchemyError):
@@ -252,12 +251,12 @@ class StatementError(SQLAlchemyError):
 
         details = [SQLAlchemyError.__str__(self)]
         if self.statement:
-            details.append("[SQL: %r]" % self.statement)
+            details.append("[SQL: {0!r}]".format(self.statement))
             if self.params:
                 params_repr = util._repr_params(self.params, 10)
-                details.append("[parameters: %r]" % params_repr)
+                details.append("[parameters: {0!r}]".format(params_repr))
         return ' '.join([
-            "(%s)" % det for det in self.detail
+            "({0!s})".format(det) for det in self.detail
         ] + details)
 
     def __unicode__(self):
@@ -304,8 +303,7 @@ class DBAPIError(StatementError):
             # raise a StatementError
             if not isinstance(orig, dbapi_base_err) and statement:
                 return StatementError(
-                    "(%s.%s) %s" %
-                    (orig.__class__.__module__, orig.__class__.__name__,
+                    "({0!s}.{1!s}) {2!s}".format(orig.__class__.__module__, orig.__class__.__name__,
                      orig),
                     statement, params, orig
                 )
@@ -333,8 +331,8 @@ class DBAPIError(StatementError):
             text = 'Error in str() of DB-API-generated exception: ' + str(e)
         StatementError.__init__(
             self,
-            '(%s.%s) %s' % (
-                orig.__class__.__module__, orig.__class__.__name__, text, ),
+            '({0!s}.{1!s}) {2!s}'.format(
+                orig.__class__.__module__, orig.__class__.__name__, text ),
             statement,
             params,
             orig

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -152,7 +152,7 @@ class AssociationProxy(interfaces.InspectionAttrInfo):
         self.proxy_bulk_set = proxy_bulk_set
 
         self.owning_class = None
-        self.key = '_%s_%s_%s' % (
+        self.key = '_{0!s}_{1!s}_{2!s}'.format(
             type(self).__name__, target_collection, id(self))
         self.collection_class = None
         if info:
@@ -708,7 +708,7 @@ class _AssociationList(_AssociationCollection):
         return repr(list(self))
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and
@@ -833,8 +833,8 @@ class _AssociationDict(_AssociationCollection):
 
     def update(self, *a, **kw):
         if len(a) > 1:
-            raise TypeError('update expected at most 1 arguments, got %i' %
-                            len(a))
+            raise TypeError('update expected at most 1 arguments, got {0:d}'.format(
+                            len(a)))
         elif len(a) == 1:
             seq_or_map = a[0]
             # discern dict from sequence - took the advice from
@@ -859,7 +859,7 @@ class _AssociationDict(_AssociationCollection):
         return dict(self.items())
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and
@@ -1059,7 +1059,7 @@ class _AssociationSet(_AssociationCollection):
         return repr(set(self))
 
     def __hash__(self):
-        raise TypeError("%s objects are unhashable" % type(self).__name__)
+        raise TypeError("{0!s} objects are unhashable".format(type(self).__name__))
 
     for func_name, func in list(locals().items()):
         if (util.callable(func) and func.__name__ == func_name and

--- a/lib/sqlalchemy/ext/automap.py
+++ b/lib/sqlalchemy/ext/automap.py
@@ -656,7 +656,7 @@ def generate_relationship(
     elif return_fn is relationship:
         return return_fn(referred_cls, **kw)
     else:
-        raise TypeError("Unknown relationship function: %s" % return_fn)
+        raise TypeError("Unknown relationship function: {0!s}".format(return_fn))
 
 
 class AutomapBase(object):

--- a/lib/sqlalchemy/ext/declarative/base.py
+++ b/lib/sqlalchemy/ext/declarative/base.py
@@ -645,8 +645,7 @@ def _declarative_constructor(self, **kwargs):
     for k in kwargs:
         if not hasattr(cls_, k):
             raise TypeError(
-                "%r is an invalid keyword argument for %s" %
-                (k, cls_.__name__))
+                "{0!r} is an invalid keyword argument for {1!s}".format(k, cls_.__name__))
         setattr(self, k, kwargs[k])
 _declarative_constructor.__name__ = '__init__'
 

--- a/lib/sqlalchemy/ext/declarative/clsregistry.py
+++ b/lib/sqlalchemy/ext/declarative/clsregistry.py
@@ -209,8 +209,7 @@ class _GetColumns(object):
         if mp:
             if key not in mp.all_orm_descriptors:
                 raise exc.InvalidRequestError(
-                    "Class %r does not have a mapped column named %r"
-                    % (self.cls, key))
+                    "Class {0!r} does not have a mapped column named {1!r}".format(self.cls, key))
 
             desc = mp.all_orm_descriptors[key]
             if desc.extension_type is interfaces.NOT_EXTENSION:

--- a/lib/sqlalchemy/ext/orderinglist.py
+++ b/lib/sqlalchemy/ext/orderinglist.py
@@ -181,7 +181,7 @@ def count_from_n_factory(start):
     def f(index, collection):
         return index + start
     try:
-        f.__name__ = 'count_from_%i' % start
+        f.__name__ = 'count_from_{0:d}'.format(start)
     except TypeError:
         pass
     return f

--- a/lib/sqlalchemy/ext/serializer.py
+++ b/lib/sqlalchemy/ext/serializer.py
@@ -141,7 +141,7 @@ def Deserializer(file, metadata=None, scoped_session=None, engine=None):
             elif type_ == "engine":
                 return get_engine()
             else:
-                raise Exception("Unknown token: %s" % type_)
+                raise Exception("Unknown token: {0!s}".format(type_))
     unpickler.persistent_load = persistent_load
     return unpickler
 

--- a/lib/sqlalchemy/log.py
+++ b/lib/sqlalchemy/log.py
@@ -174,11 +174,11 @@ def instance_logger(instance, echoflag=None):
     """create a logger for an instance that implements :class:`.Identified`."""
 
     if instance.logging_name:
-        name = "%s.%s.%s" % (instance.__class__.__module__,
+        name = "{0!s}.{1!s}.{2!s}".format(instance.__class__.__module__,
                              instance.__class__.__name__,
                              instance.logging_name)
     else:
-        name = "%s.%s" % (instance.__class__.__module__,
+        name = "{0!s}.{1!s}".format(instance.__class__.__module__,
                           instance.__class__.__name__)
 
     instance._echo = echoflag

--- a/lib/sqlalchemy/orm/attributes.py
+++ b/lib/sqlalchemy/orm/attributes.py
@@ -194,7 +194,7 @@ class QueryableAttribute(interfaces._MappedAttribute,
             )
 
     def __str__(self):
-        return "%s.%s" % (self.class_.__name__, self.key)
+        return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
     @util.memoized_property
     def property(self):
@@ -293,7 +293,7 @@ def create_proxied_attribute(descriptor):
                 return self.descriptor.__get__(instance, owner)
 
         def __str__(self):
-            return "%s.%s" % (self.class_.__name__, self.key)
+            return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
         def __getattr__(self, attribute):
             """Delegate __getattr__ to the original descriptor and/or
@@ -459,7 +459,7 @@ class AttributeImpl(object):
     )
 
     def __str__(self):
-        return "%s.%s" % (self.class_.__name__, self.key)
+        return "{0!s}.{1!s}".format(self.class_.__name__, self.key)
 
     def _get_active_history(self):
         """Backwards compat for impl.active_history"""
@@ -803,7 +803,7 @@ class ScalarObjectAttributeImpl(ScalarAttributeImpl):
                 return
             else:
                 raise ValueError(
-                    "Object %s not associated with %s on attribute '%s'" % (
+                    "Object {0!s} not associated with {1!s} on attribute '{2!s}'".format(
                         instance_str(check_old),
                         state_str(state),
                         self.key
@@ -1045,7 +1045,7 @@ class CollectionAttributeImpl(AttributeImpl):
                         iterable.__class__.__name__
                     wanted = self._duck_typed_as.__name__
                     raise TypeError(
-                        "Incompatible collection type: %s is not %s-like" % (
+                        "Incompatible collection type: {0!s} is not {1!s}-like".format(
                             given, wanted))
 
                 # If the object is an adapted collection, return the (iterable)

--- a/lib/sqlalchemy/orm/base.py
+++ b/lib/sqlalchemy/orm/base.py
@@ -225,7 +225,7 @@ def state_str(state):
     if state is None:
         return "None"
     else:
-        return '<%s at 0x%x>' % (state.class_.__name__, id(state.obj()))
+        return '<{0!s} at 0x{1:x}>'.format(state.class_.__name__, id(state.obj()))
 
 
 def state_class_str(state):
@@ -236,7 +236,7 @@ def state_class_str(state):
     if state is None:
         return "None"
     else:
-        return '<%s>' % (state.class_.__name__, )
+        return '<{0!s}>'.format(state.class_.__name__ )
 
 
 def attribute_str(instance, attribute):
@@ -379,8 +379,7 @@ def _entity_descriptor(entity, key):
         return getattr(entity, key)
     except AttributeError:
         raise sa_exc.InvalidRequestError(
-            "Entity '%s' has no property '%s'" %
-            (description, key)
+            "Entity '{0!s}' has no property '{1!s}'".format(description, key)
         )
 
 _state_mapper = util.dottedgetter('manager.mapper')
@@ -422,7 +421,7 @@ def class_mapper(class_, configure=True):
     if mapper is None:
         if not isinstance(class_, type):
             raise sa_exc.ArgumentError(
-                "Class object expected, got '%r'." % (class_, ))
+                "Class object expected, got '{0!r}'.".format(class_ ))
         raise exc.UnmappedClassError(class_)
     else:
         return mapper

--- a/lib/sqlalchemy/orm/collections.py
+++ b/lib/sqlalchemy/orm/collections.py
@@ -811,7 +811,7 @@ def __converting_factory(specimen_cls, original_factory):
         return instrumented_cls(collection)
 
     # often flawed but better than nothing
-    wrapper.__name__ = "%sWrapper" % original_factory.__name__
+    wrapper.__name__ = "{0!s}Wrapper".format(original_factory.__name__)
     wrapper.__doc__ = original_factory.__doc__
 
     return wrapper
@@ -935,7 +935,7 @@ def _set_collection_attributes(cls, roles, methods):
                                                before, argument, after))
     # intern the role map
     for role, method_name in roles.items():
-        setattr(cls, '_sa_%s' % role, getattr(cls, method_name))
+        setattr(cls, '_sa_{0!s}'.format(role), getattr(cls, method_name))
 
     cls._sa_adapter = None
 
@@ -966,7 +966,7 @@ def _instrument_membership_mutator(method, before, argument, after):
             if pos_arg is None:
                 if named_arg not in kw:
                     raise sa_exc.ArgumentError(
-                        "Missing argument %s" % argument)
+                        "Missing argument {0!s}".format(argument))
                 value = kw[named_arg]
             else:
                 if len(args) > pos_arg:
@@ -975,7 +975,7 @@ def _instrument_membership_mutator(method, before, argument, after):
                     value = kw[named_arg]
                 else:
                     raise sa_exc.ArgumentError(
-                        "Missing argument %s" % argument)
+                        "Missing argument {0!s}".format(argument))
 
         initiator = kw.pop('_sa_initiator', None)
         if initiator is False:

--- a/lib/sqlalchemy/orm/dependency.py
+++ b/lib/sqlalchemy/orm/dependency.py
@@ -316,7 +316,7 @@ class DependencyProcessor(object):
         raise NotImplementedError()
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.prop)
+        return "{0!s}({1!s})".format(self.__class__.__name__, self.prop)
 
 
 class OneToManyDP(DependencyProcessor):

--- a/lib/sqlalchemy/orm/deprecated_interfaces.py
+++ b/lib/sqlalchemy/orm/deprecated_interfaces.py
@@ -112,7 +112,7 @@ class MapperExtension(object):
                     event.listen(self.class_manager, 'init_failure',
                                  go(ls_meth), raw=False, propagate=True)
                 else:
-                    event.listen(self, "%s" % meth, ls_meth,
+                    event.listen(self, "{0!s}".format(meth), ls_meth,
                                  raw=False, retval=True, propagate=True)
 
     def instrument_class(self, mapper, class_):

--- a/lib/sqlalchemy/orm/evaluator.py
+++ b/lib/sqlalchemy/orm/evaluator.py
@@ -30,10 +30,10 @@ class EvaluatorCompiler(object):
         self.target_cls = target_cls
 
     def process(self, clause):
-        meth = getattr(self, "visit_%s" % clause.__visit_name__, None)
+        meth = getattr(self, "visit_{0!s}".format(clause.__visit_name__), None)
         if not meth:
             raise UnevaluatableError(
-                "Cannot evaluate %s" % type(clause).__name__)
+                "Cannot evaluate {0!s}".format(type(clause).__name__))
         return meth(clause)
 
     def visit_grouping(self, clause):
@@ -54,8 +54,8 @@ class EvaluatorCompiler(object):
             if self.target_cls and not issubclass(
                     self.target_cls, parentmapper.class_):
                 raise UnevaluatableError(
-                    "Can't evaluate criteria against alternate class %s" %
-                    parentmapper.class_
+                    "Can't evaluate criteria against alternate class {0!s}".format(
+                    parentmapper.class_)
                 )
             key = parentmapper._columntoproperty[clause].key
         else:
@@ -88,8 +88,8 @@ class EvaluatorCompiler(object):
                 return True
         else:
             raise UnevaluatableError(
-                "Cannot evaluate clauselist with operator %s" %
-                clause.operator)
+                "Cannot evaluate clauselist with operator {0!s}".format(
+                clause.operator))
 
         return evaluate
 
@@ -112,8 +112,7 @@ class EvaluatorCompiler(object):
                 return operator(eval_left(obj), eval_right(obj))
         else:
             raise UnevaluatableError(
-                "Cannot evaluate %s with operator %s" %
-                (type(clause).__name__, clause.operator))
+                "Cannot evaluate {0!s} with operator {1!s}".format(type(clause).__name__, clause.operator))
         return evaluate
 
     def visit_unary(self, clause):
@@ -126,8 +125,7 @@ class EvaluatorCompiler(object):
                 return not value
             return evaluate
         raise UnevaluatableError(
-            "Cannot evaluate %s with operator %s" %
-            (type(clause).__name__, clause.operator))
+            "Cannot evaluate {0!s} with operator {1!s}".format(type(clause).__name__, clause.operator))
 
     def visit_bindparam(self, clause):
         if clause.callable:

--- a/lib/sqlalchemy/orm/exc.py
+++ b/lib/sqlalchemy/orm/exc.py
@@ -162,4 +162,4 @@ def _default_unmapped(base, cls):
     name = _safe_cls_name(cls)
 
     if not mappers:
-        return "Class '%s' is not mapped" % name
+        return "Class '{0!s}' is not mapped".format(name)

--- a/lib/sqlalchemy/orm/instrumentation.py
+++ b/lib/sqlalchemy/orm/instrumentation.py
@@ -362,7 +362,7 @@ class ClassManager(dict):
     __nonzero__ = __bool__
 
     def __repr__(self):
-        return '<%s of %r at %x>' % (
+        return '<{0!s} of {1!r} at {2:x}>'.format(
             self.__class__.__name__, self.class_, id(self))
 
 

--- a/lib/sqlalchemy/orm/interfaces.py
+++ b/lib/sqlalchemy/orm/interfaces.py
@@ -241,7 +241,7 @@ class MapperProperty(_MappedAttribute, InspectionAttr, util.MemoizedSlots):
         """
 
     def __repr__(self):
-        return '<%s at 0x%x; %s>' % (
+        return '<{0!s} at 0x{1:x}; {2!s}>'.format(
             self.__class__.__name__,
             id(self), getattr(self, 'key', 'no key'))
 
@@ -342,7 +342,7 @@ class PropComparator(operators.ColumnOperators):
         self._adapt_to_entity = adapt_to_entity
 
     def __clause_element__(self):
-        raise NotImplementedError("%r" % self)
+        raise NotImplementedError("{0!r}".format(self))
 
     def _query_clause_element(self):
         return self.__clause_element__()
@@ -549,7 +549,7 @@ class StrategizedProperty(MapperProperty):
                     return strategies[key]
                 except KeyError:
                     pass
-        raise Exception("can't locate strategy for %s %s" % (cls, key))
+        raise Exception("can't locate strategy for {0!s} {1!s}".format(cls, key))
 
 
 class MapperOption(object):

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -584,8 +584,8 @@ def _decorate_polymorphic_switch(
             sub_mapper = mapper.polymorphic_map[discriminator]
         except KeyError:
             raise AssertionError(
-                "No such polymorphic_identity %r is defined" %
-                discriminator)
+                "No such polymorphic_identity {0!r} is defined".format(
+                discriminator))
         else:
             if sub_mapper is mapper:
                 return None

--- a/lib/sqlalchemy/orm/mapper.py
+++ b/lib/sqlalchemy/orm/mapper.py
@@ -948,8 +948,7 @@ class Mapper(InspectionAttr):
                 self.inherits = class_mapper(self.inherits, configure=False)
             if not issubclass(self.class_, self.inherits.class_):
                 raise sa_exc.ArgumentError(
-                    "Class '%s' does not inherit from '%s'" %
-                    (self.class_.__name__, self.inherits.class_.__name__))
+                    "Class '{0!s}' does not inherit from '{1!s}'".format(self.class_.__name__, self.inherits.class_.__name__))
             if self.non_primary != self.inherits.non_primary:
                 np = not self.non_primary and "primary" or "non-primary"
                 raise sa_exc.ArgumentError(
@@ -1045,8 +1044,7 @@ class Mapper(InspectionAttr):
 
         if self.mapped_table is None:
             raise sa_exc.ArgumentError(
-                "Mapper '%s' does not have a mapped_table specified."
-                % self)
+                "Mapper '{0!s}' does not have a mapped_table specified.".format(self))
 
     def _set_with_polymorphic(self, with_polymorphic):
         if with_polymorphic == '*':
@@ -1684,8 +1682,7 @@ class Mapper(InspectionAttr):
         column = columns[0]
         if not expression._is_column(column):
             raise sa_exc.ArgumentError(
-                "%s=%r is not an instance of MapperProperty or Column"
-                % (key, prop))
+                "{0!s}={1!r} is not an instance of MapperProperty or Column".format(key, prop))
 
         prop = self._props.get(key, None)
 
@@ -1818,11 +1815,11 @@ class Mapper(InspectionAttr):
         )
 
     def __repr__(self):
-        return '<Mapper at 0x%x; %s>' % (
+        return '<Mapper at 0x{0:x}; {1!s}>'.format(
             id(self), self.class_.__name__)
 
     def __str__(self):
-        return "Mapper|%s|%s%s" % (
+        return "Mapper|{0!s}|{1!s}{2!s}".format(
             self.class_.__name__,
             self.local_table is not None and
             self.local_table.description or None,
@@ -1862,7 +1859,7 @@ class Mapper(InspectionAttr):
             return self._props[key]
         except KeyError:
             raise sa_exc.InvalidRequestError(
-                "Mapper '%s' has no property '%s'" % (self, key))
+                "Mapper '{0!s}' has no property '{1!s}'".format(self, key))
 
     def get_property_by_column(self, column):
         """Given a :class:`.Column` object, return the
@@ -1893,8 +1890,7 @@ class Mapper(InspectionAttr):
                 m = _class_to_mapper(m)
                 if not m.isa(self):
                     raise sa_exc.InvalidRequestError(
-                        "%r does not inherit from %r" %
-                        (m, self))
+                        "{0!r} does not inherit from {1!r}".format(m, self))
 
                 if selectable is None:
                     mappers.update(m.iterate_to_root())
@@ -2348,7 +2344,7 @@ class Mapper(InspectionAttr):
         if self.include_properties is not None and \
                 name not in self.include_properties and \
                 (column is None or column not in self.include_properties):
-            self._log("not including property %s" % (name))
+            self._log("not including property {0!s}".format((name)))
             return True
 
         if self.exclude_properties is not None and \
@@ -2356,7 +2352,7 @@ class Mapper(InspectionAttr):
                     name in self.exclude_properties or
                     (column is not None and column in self.exclude_properties)
                 ):
-            self._log("excluding property %s" % (name))
+            self._log("excluding property {0!s}".format((name)))
             return True
 
         return False
@@ -2979,5 +2975,4 @@ class _ColumnMapping(dict):
                 "conflicting property '%s':%r" % (
                     column.table.name, column.name, column.key, prop))
         raise orm_exc.UnmappedColumnError(
-            "No column %s is configured on mapper %s..." %
-            (column, self.mapper))
+            "No column {0!s} is configured on mapper {1!s}...".format(column, self.mapper))

--- a/lib/sqlalchemy/orm/path_registry.py
+++ b/lib/sqlalchemy/orm/path_registry.py
@@ -138,7 +138,7 @@ class PathRegistry(object):
         elif token.endswith(":" + _DEFAULT_TOKEN):
             return TokenRegistry(self.root, token)
         else:
-            raise exc.ArgumentError("invalid token: %s" % token)
+            raise exc.ArgumentError("invalid token: {0!s}".format(token))
 
     def __add__(self, other):
         return util.reduce(
@@ -146,7 +146,7 @@ class PathRegistry(object):
             other.path, self)
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.path, )
+        return "{0!s}({1!r})".format(self.__class__.__name__, self.path )
 
 
 class RootRegistry(PathRegistry):
@@ -225,7 +225,7 @@ class PropRegistry(PathRegistry):
         """
         return ("loader",
                 self.parent.token(
-                    "%s:%s" % (
+                    "{0!s}:{1!s}".format(
                         self.prop.strategy_wildcard_key, _WILDCARD_TOKEN)
                 ).path
                 )
@@ -234,7 +234,7 @@ class PropRegistry(PathRegistry):
     def _default_path_loader_key(self):
         return ("loader",
                 self.parent.token(
-                    "%s:%s" % (self.prop.strategy_wildcard_key,
+                    "{0!s}:{1!s}".format(self.prop.strategy_wildcard_key,
                                _DEFAULT_TOKEN)
                 ).path
                 )

--- a/lib/sqlalchemy/orm/persistence.py
+++ b/lib/sqlalchemy/orm/persistence.py
@@ -1276,7 +1276,7 @@ class BulkUpdate(BulkUD):
                 return attr.key
         else:
             raise sa_exc.InvalidRequestError(
-                "Invalid expression type: %r" % key)
+                "Invalid expression type: {0!r}".format(key))
 
     def _do_exec(self):
 

--- a/lib/sqlalchemy/orm/properties.py
+++ b/lib/sqlalchemy/orm/properties.py
@@ -146,7 +146,7 @@ class ColumnProperty(StrategizedProperty):
 
         if kwargs:
             raise TypeError(
-                "%s received unexpected keyword argument(s): %s" % (
+                "{0!s} received unexpected keyword argument(s): {1!s}".format(
                     self.__class__.__name__,
                     ', '.join(sorted(kwargs.keys()))))
 

--- a/lib/sqlalchemy/orm/query.py
+++ b/lib/sqlalchemy/orm/query.py
@@ -841,7 +841,7 @@ class Query(object):
             raise sa_exc.InvalidRequestError(
                 "Incorrect number of values in identifier to formulate "
                 "primary key for query.get(); primary key columns are %s" %
-                ','.join("'%s'" % c for c in mapper.primary_key))
+                ','.join("'{0!s}'".format(c) for c in mapper.primary_key))
 
         key = mapper.identity_key_from_primary_key(ident)
 
@@ -1961,8 +1961,8 @@ class Query(object):
             kwargs.pop('isouter', False),\
             kwargs.pop('full', False)
         if kwargs:
-            raise TypeError("unknown arguments: %s" %
-                            ', '.join(sorted(kwargs)))
+            raise TypeError("unknown arguments: {0!s}".format(
+                            ', '.join(sorted(kwargs))))
         return self._join(props,
                           outerjoin=isouter, full=full,
                           create_aliases=aliased,
@@ -1979,8 +1979,8 @@ class Query(object):
             kwargs.pop('from_joinpoint', False), \
             kwargs.pop('full', False)
         if kwargs:
-            raise TypeError("unknown arguments: %s" %
-                            ', '.join(sorted(kwargs)))
+            raise TypeError("unknown arguments: {0!s}".format(
+                            ', '.join(sorted(kwargs))))
         return self._join(props,
                           outerjoin=True, full=full, create_aliases=aliased,
                           from_joinpoint=from_joinpoint)
@@ -2126,7 +2126,7 @@ class Query(object):
 
         if left is None:
             if self._entities:
-                problem = "Don't know how to join from %s" % self._entities[0]
+                problem = "Don't know how to join from {0!s}".format(self._entities[0])
             else:
                 problem = "No entities to join from"
 
@@ -2165,8 +2165,8 @@ class Query(object):
         if (overlap or not create_aliases) and \
                 l_info.selectable is r_info.selectable:
             raise sa_exc.InvalidRequestError(
-                "Can't join table/selectable '%s' to itself" %
-                l_info.selectable)
+                "Can't join table/selectable '{0!s}' to itself".format(
+                l_info.selectable))
 
         right, onclause = self._prepare_right_side(
             r_info, right, onclause,
@@ -2213,8 +2213,7 @@ class Query(object):
             if not right_selectable.is_derived_from(
                     right_mapper.mapped_table):
                 raise sa_exc.InvalidRequestError(
-                    "Selectable '%s' is not derived from '%s'" %
-                    (right_selectable.description,
+                    "Selectable '{0!s}' is not derived from '{1!s}'".format(right_selectable.description,
                      right_mapper.mapped_table.description))
 
             if isinstance(right_selectable, expression.SelectBase):
@@ -3442,7 +3441,7 @@ class LockmodeArg(ForUpdateArg):
             read = False
         else:
             raise sa_exc.ArgumentError(
-                "Unknown with_lockmode argument: %r" % mode)
+                "Unknown with_lockmode argument: {0!r}".format(mode))
 
         return LockmodeArg(read=read, nowait=nowait)
 

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1993,19 +1993,19 @@ class JoinCondition(object):
         log.info('%s setup secondary join %s', self.prop,
                  self.secondaryjoin)
         log.info('%s synchronize pairs [%s]', self.prop,
-                 ','.join('(%s => %s)' % (l, r) for (l, r) in
+                 ','.join('({0!s} => {1!s})'.format(l, r) for (l, r) in
                           self.synchronize_pairs))
         log.info('%s secondary synchronize pairs [%s]', self.prop,
-                 ','.join('(%s => %s)' % (l, r) for (l, r) in
+                 ','.join('({0!s} => {1!s})'.format(l, r) for (l, r) in
                           self.secondary_synchronize_pairs or []))
         log.info('%s local/remote pairs [%s]', self.prop,
-                 ','.join('(%s / %s)' % (l, r) for (l, r) in
+                 ','.join('({0!s} / {1!s})'.format(l, r) for (l, r) in
                           self.local_remote_pairs))
         log.info('%s remote columns [%s]', self.prop,
-                 ','.join('%s' % col for col in self.remote_columns)
+                 ','.join('{0!s}'.format(col) for col in self.remote_columns)
                  )
         log.info('%s local columns [%s]', self.prop,
-                 ','.join('%s' % col for col in self.local_columns)
+                 ','.join('{0!s}'.format(col) for col in self.local_columns)
                  )
         log.info('%s relationship direction %s', self.prop,
                  self.direction)
@@ -2678,7 +2678,7 @@ class JoinCondition(object):
                             self.prop,
                             from_, to_,
                             ", ".join(
-                                "'%s' (copies %s to %s)" % (pr, fr_, to_)
+                                "'{0!s}' (copies {1!s} to {2!s})".format(pr, fr_, to_)
                                 for (pr, fr_) in other_props)
                         )
                     )

--- a/lib/sqlalchemy/orm/session.py
+++ b/lib/sqlalchemy/orm/session.py
@@ -245,8 +245,8 @@ class SessionTransaction(object):
                 break
             elif current._parent is None:
                 raise sa_exc.InvalidRequestError(
-                    "Transaction %s is not on the active transaction list" % (
-                        upto))
+                    "Transaction {0!s} is not on the active transaction list".format((
+                        upto)))
             else:
                 current = current._parent
 
@@ -1123,8 +1123,8 @@ class Session(_SessionClassMethods):
         except sa_exc.NoInspectionAvailable:
             if not isinstance(key, type):
                 raise exc.ArgumentError(
-                            "Not acceptable bind target: %s" %
-                            key)
+                            "Not acceptable bind target: {0!s}".format(
+                            key))
             else:
                 self.__binds[key] = bind
         else:
@@ -1136,8 +1136,8 @@ class Session(_SessionClassMethods):
                     self.__binds[selectable] = bind
             else:
                 raise exc.ArgumentError(
-                            "Not acceptable bind target: %s" %
-                            key)
+                            "Not acceptable bind target: {0!s}".format(
+                            key))
 
     def bind_mapper(self, mapper, bind):
         """Associate a :class:`.Mapper` with a "bind", e.g. a :class:`.Engine`
@@ -1254,13 +1254,13 @@ class Session(_SessionClassMethods):
 
         context = []
         if mapper is not None:
-            context.append('mapper %s' % mapper)
+            context.append('mapper {0!s}'.format(mapper))
         if clause is not None:
             context.append('SQL expression')
 
         raise sa_exc.UnboundExecutionError(
-            "Could not locate a bind configured on %s or this Session" % (
-                ', '.join(context)))
+            "Could not locate a bind configured on {0!s} or this Session".format((
+                ', '.join(context))))
 
     def query(self, *entities, **kwargs):
         """Return a new :class:`.Query` object corresponding to this
@@ -1360,8 +1360,8 @@ class Session(_SessionClassMethods):
                 lockmode=lockmode,
                 only_load_props=attribute_names) is None:
             raise sa_exc.InvalidRequestError(
-                "Could not refresh instance '%s'" %
-                instance_str(instance))
+                "Could not refresh instance '{0!s}'".format(
+                instance_str(instance)))
 
     def expire_all(self):
         """Expires all persistent instances within this Session.
@@ -1487,8 +1487,8 @@ class Session(_SessionClassMethods):
             raise exc.UnmappedInstanceError(instance)
         if state.session_id is not self.hash_key:
             raise sa_exc.InvalidRequestError(
-                "Instance %s is not present in this Session" %
-                state_str(state))
+                "Instance {0!s} is not present in this Session".format(
+                state_str(state)))
 
         cascaded = list(state.manager.mapper.cascade_iterator(
             'expunge', state))
@@ -1650,8 +1650,8 @@ class Session(_SessionClassMethods):
         if state.key is None:
             if head:
                 raise sa_exc.InvalidRequestError(
-                    "Instance '%s' is not persisted" %
-                    state_str(state))
+                    "Instance '{0!s}' is not persisted".format(
+                    state_str(state)))
             else:
                 return
 
@@ -1865,8 +1865,8 @@ class Session(_SessionClassMethods):
     def _validate_persistent(self, state):
         if not self.identity_map.contains_state(state):
             raise sa_exc.InvalidRequestError(
-                "Instance '%s' is not persistent within this Session" %
-                state_str(state))
+                "Instance '{0!s}' is not persistent within this Session".format(
+                state_str(state)))
 
     def _save_impl(self, state):
         if state.key is not None:
@@ -1885,8 +1885,8 @@ class Session(_SessionClassMethods):
     def _update_impl(self, state, revert_deletion=False):
         if state.key is None:
             raise sa_exc.InvalidRequestError(
-                "Instance '%s' is not persisted" %
-                state_str(state))
+                "Instance '{0!s}' is not persisted".format(
+                state_str(state)))
 
         if state._deleted:
             if revert_deletion:
@@ -2763,10 +2763,10 @@ class sessionmaker(_SessionClassMethods):
         self.kw.update(new_kw)
 
     def __repr__(self):
-        return "%s(class_=%r,%s)" % (
+        return "{0!s}(class_={1!r},{2!s})".format(
             self.__class__.__name__,
             self.class_.__name__,
-            ", ".join("%s=%r" % (k, v) for k, v in self.kw.items())
+            ", ".join("{0!s}={1!r}".format(k, v) for k, v in self.kw.items())
         )
 
 

--- a/lib/sqlalchemy/orm/strategies.py
+++ b/lib/sqlalchemy/orm/strategies.py
@@ -250,7 +250,7 @@ class DeferredColumnLoader(LoaderStrategy):
             (
                 loadopt and
                 self.group and
-                loadopt.local_opts.get('undefer_group_%s' % self.group, False)
+                loadopt.local_opts.get('undefer_group_{0!s}'.format(self.group), False)
             )
             or
             (
@@ -381,7 +381,7 @@ class RaiseLoader(NoLoader):
 
         def invoke_raise_load(state, passive):
             raise sa_exc.InvalidRequestError(
-                "'%s' is not available due to lazy='raise'" % self
+                "'{0!s}' is not available due to lazy='raise'".format(self)
             )
 
         set_lazy_callable = InstanceState._instance_level_callable_processor(

--- a/lib/sqlalchemy/orm/strategy_options.py
+++ b/lib/sqlalchemy/orm/strategy_options.py
@@ -128,7 +128,7 @@ class Load(Generative, MapperOption):
                 if default_token:
                     self.propagate_to_loaders = False
                 if wildcard_key:
-                    attr = "%s:%s" % (wildcard_key, attr)
+                    attr = "{0!s}:{1!s}".format(wildcard_key, attr)
                 return path.token(attr)
 
             try:
@@ -183,7 +183,7 @@ class Load(Generative, MapperOption):
         return path
 
     def __str__(self):
-        return "Load(strategy=%r)" % (self.strategy, )
+        return "Load(strategy={0!r})".format(self.strategy )
 
     def _coerce_strat(self, strategy):
         if strategy is not None:
@@ -262,7 +262,7 @@ class Load(Generative, MapperOption):
 
                 if i == 0 and c_token.endswith(':' + _DEFAULT_TOKEN):
                     return to_chop
-                elif c_token != 'relationship:%s' % (_WILDCARD_TOKEN,) and \
+                elif c_token != 'relationship:{0!s}'.format(_WILDCARD_TOKEN) and \
                         c_token != p_token.key:
                     return None
 
@@ -299,7 +299,7 @@ class _UnboundLoad(Load):
                 attr in (_WILDCARD_TOKEN, _DEFAULT_TOKEN):
             if attr == _DEFAULT_TOKEN:
                 self.propagate_to_loaders = False
-            attr = "%s:%s" % (wildcard_key, attr)
+            attr = "{0!s}:{1!s}".format(wildcard_key, attr)
 
         return path + (attr, )
 
@@ -364,8 +364,8 @@ class _UnboundLoad(Load):
             if isinstance(c_token, util.string_types):
                 if i == 0 and c_token.endswith(':' + _DEFAULT_TOKEN):
                     return to_chop
-                elif c_token != 'relationship:%s' % (
-                        _WILDCARD_TOKEN,) and c_token != p_prop.key:
+                elif c_token != 'relationship:{0!s}'.format(
+                        _WILDCARD_TOKEN) and c_token != p_prop.key:
                     return None
             elif isinstance(c_token, PropComparator):
                 if c_token.property is not p_prop:
@@ -508,7 +508,7 @@ class loader_option(object):
         self.name = name = fn.__name__
         self.fn = fn
         if hasattr(Load, name):
-            raise TypeError("Load class already has a %s method." % (name))
+            raise TypeError("Load class already has a {0!s} method.".format((name)))
         setattr(Load, name, fn)
 
         return self
@@ -517,28 +517,28 @@ class loader_option(object):
         self._unbound_fn = fn
         fn_doc = self.fn.__doc__
         self.fn.__doc__ = """Produce a new :class:`.Load` object with the
-:func:`.orm.%(name)s` option applied.
+:func:`.orm.{name!s}` option applied.
 
-See :func:`.orm.%(name)s` for usage examples.
+See :func:`.orm.{name!s}` for usage examples.
 
-""" % {"name": self.name}
+""".format(**{"name": self.name})
 
         fn.__doc__ = fn_doc
         return self
 
     def _add_unbound_all_fn(self, fn):
         self._unbound_all_fn = fn
-        fn.__doc__ = """Produce a standalone "all" option for :func:`.orm.%(name)s`.
+        fn.__doc__ = """Produce a standalone "all" option for :func:`.orm.{name!s}`.
 
 .. deprecated:: 0.9.0
 
     The "_all()" style is replaced by method chaining, e.g.::
 
         session.query(MyClass).options(
-            %(name)s("someattribute").%(name)s("anotherattribute")
+            {name!s}("someattribute").{name!s}("anotherattribute")
         )
 
-""" % {"name": self.name}
+""".format(**{"name": self.name})
         return self
 
 
@@ -1082,7 +1082,7 @@ def undefer_group(loadopt, name):
     return loadopt.set_column_strategy(
         "*",
         None,
-        {"undefer_group_%s" % name: True},
+        {"undefer_group_{0!s}".format(name): True},
         opts_only=True
     )
 

--- a/lib/sqlalchemy/orm/unitofwork.py
+++ b/lib/sqlalchemy/orm/unitofwork.py
@@ -478,7 +478,7 @@ class PostSortRec(object):
         self.execute(uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             ",".join(str(x) for x in self.__dict__.values())
         )
@@ -507,7 +507,7 @@ class ProcessAll(IterateMappersMixin, PostSortRec):
         return iter([])
 
     def __repr__(self):
-        return "%s(%s, delete=%s)" % (
+        return "{0!s}({1!s}, delete={2!s})".format(
             self.__class__.__name__,
             self.dependency_processor,
             self.delete
@@ -613,7 +613,7 @@ class ProcessState(PostSortRec):
             dependency_processor.process_saves(uow, states)
 
     def __repr__(self):
-        return "%s(%s, %s, delete=%s)" % (
+        return "{0!s}({1!s}, {2!s}, delete={3!s})".format(
             self.__class__.__name__,
             self.dependency_processor,
             orm_util.state_str(self.state),
@@ -639,7 +639,7 @@ class SaveUpdateState(PostSortRec):
                              uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             orm_util.state_str(self.state)
         )
@@ -663,7 +663,7 @@ class DeleteState(PostSortRec):
                                uow)
 
     def __repr__(self):
-        return "%s(%s)" % (
+        return "{0!s}({1!s})".format(
             self.__class__.__name__,
             orm_util.state_str(self.state)
         )

--- a/lib/sqlalchemy/orm/util.py
+++ b/lib/sqlalchemy/orm/util.py
@@ -40,9 +40,9 @@ class CascadeOptions(frozenset):
         values = set(value_list)
         if values.difference(cls._allowed_cascades):
             raise sa_exc.ArgumentError(
-                "Invalid cascade option(s): %s" %
+                "Invalid cascade option(s): {0!s}".format(
                 ", ".join([repr(x) for x in
-                           sorted(values.difference(cls._allowed_cascades))]))
+                           sorted(values.difference(cls._allowed_cascades))])))
 
         if "all" in values:
             values.update(cls._add_w_all_cascades)
@@ -64,9 +64,9 @@ class CascadeOptions(frozenset):
         return self
 
     def __repr__(self):
-        return "CascadeOptions(%r)" % (
+        return "CascadeOptions({0!r})".format((
             ",".join([x for x in sorted(self)])
-        )
+        ))
 
     @classmethod
     def from_string(cls, arg):
@@ -262,16 +262,14 @@ first()
                 "expected up to three positional arguments, "
                 "got %s" % len(args))
         if kwargs:
-            raise sa_exc.ArgumentError("unknown keyword arguments: %s"
-                                       % ", ".join(kwargs))
+            raise sa_exc.ArgumentError("unknown keyword arguments: {0!s}".format(", ".join(kwargs)))
         mapper = class_mapper(class_)
         if "ident" in locals():
             return mapper.identity_key_from_primary_key(util.to_list(ident))
         return mapper.identity_key_from_row(row)
     instance = kwargs.pop("instance")
     if kwargs:
-        raise sa_exc.ArgumentError("unknown keyword arguments: %s"
-                                   % ", ".join(kwargs.keys))
+        raise sa_exc.ArgumentError("unknown keyword arguments: {0!s}".format(", ".join(kwargs.keys)))
     mapper = object_mapper(instance)
     return mapper.identity_key_from_instance(instance)
 
@@ -379,7 +377,7 @@ class AliasedClass(object):
             adapt_on_names
         )
 
-        self.__name__ = 'AliasedClass_%s' % mapper.class_.__name__
+        self.__name__ = 'AliasedClass_{0!s}'.format(mapper.class_.__name__)
 
     def __getattr__(self, key):
         try:
@@ -417,7 +415,7 @@ class AliasedClass(object):
             return attr
 
     def __repr__(self):
-        return '<AliasedClass at 0x%x; %s>' % (
+        return '<AliasedClass at 0x{0:x}; {1!s}>'.format(
             id(self), self._aliased_insp._target.__name__)
 
 
@@ -545,16 +543,16 @@ class AliasedInsp(InspectionAttr):
         elif mapper.isa(self.mapper):
             return self
         else:
-            assert False, "mapper %s doesn't correspond to %s" % (
+            assert False, "mapper {0!s} doesn't correspond to {1!s}".format(
                 mapper, self)
 
     def __repr__(self):
         if self.with_polymorphic_mappers:
-            with_poly = "(%s)" % ", ".join(
-                mp.class_.__name__ for mp in self.with_polymorphic_mappers)
+            with_poly = "({0!s})".format(", ".join(
+                mp.class_.__name__ for mp in self.with_polymorphic_mappers))
         else:
             with_poly = ""
-        return '<AliasedInsp at 0x%x; %s%s>' % (
+        return '<AliasedInsp at 0x{0:x}; {1!s}{2!s}>'.format(
             id(self), self.class_.__name__, with_poly)
 
 

--- a/lib/sqlalchemy/pool.py
+++ b/lib/sqlalchemy/pool.py
@@ -230,8 +230,7 @@ class Pool(log.Identified):
             self._reset_on_return = reset_commit
         else:
             raise exc.ArgumentError(
-                "Invalid value for 'reset_on_return': %r"
-                % reset_on_return)
+                "Invalid value for 'reset_on_return': {0!r}".format(reset_on_return))
 
         self.echo = echo
 
@@ -959,8 +958,7 @@ class SingletonThreadPool(Pool):
             c.close()
 
     def status(self):
-        return "SingletonThreadPool id:%d size: %d" % \
-            (id(self), len(self._all_conns))
+        return "SingletonThreadPool id:{0:d} size: {1:d}".format(id(self), len(self._all_conns))
 
     def _do_return_conn(self, conn):
         pass
@@ -1269,8 +1267,8 @@ class AssertionPool(Pool):
     def _do_get(self):
         if self._checked_out:
             if self._checkout_traceback:
-                suffix = ' at:\n%s' % ''.join(
-                    chop_traceback(self._checkout_traceback))
+                suffix = ' at:\n{0!s}'.format(''.join(
+                    chop_traceback(self._checkout_traceback)))
             else:
                 suffix = ''
             raise AssertionError("connection is already checked out" + suffix)

--- a/lib/sqlalchemy/processors.py
+++ b/lib/sqlalchemy/processors.py
@@ -86,7 +86,7 @@ def py_fallback():
         return process
 
     def to_decimal_processor_factory(target_class, scale):
-        fstring = "%%.%df" % scale
+        fstring = "%.{0:d}f".format(scale)
 
         def process(value):
             if value is None:
@@ -149,7 +149,7 @@ try:
         # For example, the Python implementation might return
         # Decimal('5.00000') whereas the C implementation will
         # return Decimal('5'). These are equivalent of course.
-        return DecimalResultProcessor(target_class, "%%.%df" % scale).process
+        return DecimalResultProcessor(target_class, "%.{0:d}f".format(scale)).process
 
 except ImportError:
     globals().update(py_fallback())

--- a/lib/sqlalchemy/sql/annotation.py
+++ b/lib/sqlalchemy/sql/annotation.py
@@ -181,9 +181,9 @@ def _new_annotation_type(cls, base_cls):
             break
 
     annotated_classes[cls] = anno_cls = type(
-        "Annotated%s" % cls.__name__,
+        "Annotated{0!s}".format(cls.__name__),
         (base_cls, cls), {})
-    globals()["Annotated%s" % cls.__name__] = anno_cls
+    globals()["Annotated{0!s}".format(cls.__name__)] = anno_cls
     return anno_cls
 
 

--- a/lib/sqlalchemy/sql/base.py
+++ b/lib/sqlalchemy/sql/base.py
@@ -92,7 +92,7 @@ class _DialectArgView(collections.MutableMapping):
 
     def __iter__(self):
         return (
-            util.safe_kwarg("%s_%s" % (dialect_name, value_name))
+            util.safe_kwarg("{0!s}_{1!s}".format(dialect_name, value_name))
             for dialect_name in self.obj.dialect_options
             for value_name in
             self.obj.dialect_options[dialect_name]._non_defaults
@@ -624,9 +624,9 @@ def _bind_or_error(schemaitem, msg=None):
         label = getattr(schemaitem, 'fullname',
                         getattr(schemaitem, 'name', None))
         if label:
-            item = '%s object %r' % (name, label)
+            item = '{0!s} object {1!r}'.format(name, label)
         else:
-            item = '%s object' % name
+            item = '{0!s} object'.format(name)
         if msg is None:
             msg = "%s is not bound to an Engine or Connection.  "\
                 "Execution can not proceed without a database to execute "\

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -515,8 +515,7 @@ class SQLCompiler(Compiled):
                             (bindparam.key, _group_number))
                     else:
                         raise exc.InvalidRequestError(
-                            "A value is required for bind parameter %r"
-                            % bindparam.key)
+                            "A value is required for bind parameter {0!r}".format(bindparam.key))
 
                 elif bindparam.callable:
                     pd[name] = bindparam.effective_value
@@ -534,8 +533,7 @@ class SQLCompiler(Compiled):
                             (bindparam.key, _group_number))
                     else:
                         raise exc.InvalidRequestError(
-                            "A value is required for bind parameter %r"
-                            % bindparam.key)
+                            "A value is required for bind parameter {0!r}".format(bindparam.key))
 
                 if bindparam.callable:
                     pd[self.bind_names[bindparam]] = bindparam.effective_value
@@ -767,7 +765,7 @@ class SQLCompiler(Compiled):
 
         text = self.process(taf.element, **kw)
         if asfrom and parens:
-            text = "(%s)" % text
+            text = "({0!s})".format(text)
         return text
 
     def visit_null(self, expr, **kw):
@@ -818,37 +816,36 @@ class SQLCompiler(Compiled):
         return type_coerce.typed_expression._compiler_dispatch(self, **kw)
 
     def visit_cast(self, cast, **kwargs):
-        return "CAST(%s AS %s)" % \
-            (cast.clause._compiler_dispatch(self, **kwargs),
+        return "CAST({0!s} AS {1!s})".format(cast.clause._compiler_dispatch(self, **kwargs),
              cast.typeclause._compiler_dispatch(self, **kwargs))
 
     def _format_frame_clause(self, range_, **kw):
-        return '%s AND %s' % (
+        return '{0!s} AND {1!s}'.format(
             "UNBOUNDED PRECEDING"
             if range_[0] is elements.RANGE_UNBOUNDED
             else "CURRENT ROW" if range_[0] is elements.RANGE_CURRENT
-            else "%s PRECEDING" % (self.process(range_[0], **kw), ),
+            else "{0!s} PRECEDING".format(self.process(range_[0], **kw) ),
 
             "UNBOUNDED FOLLOWING"
             if range_[1] is elements.RANGE_UNBOUNDED
             else "CURRENT ROW" if range_[1] is elements.RANGE_CURRENT
-            else "%s FOLLOWING" % (self.process(range_[1], **kw), )
+            else "{0!s} FOLLOWING".format(self.process(range_[1], **kw) )
         )
 
     def visit_over(self, over, **kwargs):
         if over.range_:
-            range_ = "RANGE BETWEEN %s" % self._format_frame_clause(
-                over.range_, **kwargs)
+            range_ = "RANGE BETWEEN {0!s}".format(self._format_frame_clause(
+                over.range_, **kwargs))
         elif over.rows:
-            range_ = "ROWS BETWEEN %s" % self._format_frame_clause(
-                over.rows, **kwargs)
+            range_ = "ROWS BETWEEN {0!s}".format(self._format_frame_clause(
+                over.rows, **kwargs))
         else:
             range_ = None
 
-        return "%s OVER (%s)" % (
+        return "{0!s} OVER ({1!s})".format(
             over.element._compiler_dispatch(self, **kwargs),
             ' '.join([
-                '%s BY %s' % (
+                '{0!s} BY {1!s}'.format(
                     word, clause._compiler_dispatch(self, **kwargs)
                 )
                 for word, clause in (
@@ -861,20 +858,20 @@ class SQLCompiler(Compiled):
         )
 
     def visit_withingroup(self, withingroup, **kwargs):
-        return "%s WITHIN GROUP (ORDER BY %s)" % (
+        return "{0!s} WITHIN GROUP (ORDER BY {1!s})".format(
             withingroup.element._compiler_dispatch(self, **kwargs),
             withingroup.order_by._compiler_dispatch(self, **kwargs)
         )
 
     def visit_funcfilter(self, funcfilter, **kwargs):
-        return "%s FILTER (WHERE %s)" % (
+        return "{0!s} FILTER (WHERE {1!s})".format(
             funcfilter.func._compiler_dispatch(self, **kwargs),
             funcfilter.criterion._compiler_dispatch(self, **kwargs)
         )
 
     def visit_extract(self, extract, **kwargs):
         field = self.extract_map.get(extract.field, extract.field)
-        return "EXTRACT(%s FROM %s)" % (
+        return "EXTRACT({0!s} FROM {1!s})".format(
             field, extract.expr._compiler_dispatch(self, **kwargs))
 
     def visit_function(self, func, add_to_result_map=None, **kwargs):
@@ -883,7 +880,7 @@ class SQLCompiler(Compiled):
                 func.name, func.name, (), func.type
             )
 
-        disp = getattr(self, "visit_%s_func" % func.name.lower(), None)
+        disp = getattr(self, "visit_{0!s}_func".format(func.name.lower()), None)
         if disp:
             return disp(func, **kwargs)
         else:
@@ -896,8 +893,8 @@ class SQLCompiler(Compiled):
 
     def visit_sequence(self, sequence):
         raise NotImplementedError(
-            "Dialect '%s' does not support sequence increments." %
-            self.dialect.name
+            "Dialect '{0!s}' does not support sequence increments.".format(
+            self.dialect.name)
         )
 
     def function_argspec(self, func, **kwargs):
@@ -948,7 +945,7 @@ class SQLCompiler(Compiled):
             return text
 
     def _get_operator_dispatch(self, operator_, qualifier1, qualifier2):
-        attrname = "visit_%s_%s%s" % (
+        attrname = "visit_{0!s}_{1!s}{2!s}".format(
             operator_.__name__, qualifier1,
             "_" + qualifier2 if qualifier2 else "")
         return getattr(self, attrname, None)
@@ -982,17 +979,17 @@ class SQLCompiler(Compiled):
         if self.dialect.supports_native_boolean:
             return self.process(element.element, **kw)
         else:
-            return "%s = 1" % self.process(element.element, **kw)
+            return "{0!s} = 1".format(self.process(element.element, **kw))
 
     def visit_isfalse_unary_operator(self, element, operator, **kw):
         if self.dialect.supports_native_boolean:
-            return "NOT %s" % self.process(element.element, **kw)
+            return "NOT {0!s}".format(self.process(element.element, **kw))
         else:
-            return "%s = 0" % self.process(element.element, **kw)
+            return "{0!s} = 0".format(self.process(element.element, **kw))
 
     def visit_notmatch_op_binary(self, binary, operator, **kw):
-        return "NOT %s" % self.visit_binary(
-            binary, override_operator=operators.match_op)
+        return "NOT {0!s}".format(self.visit_binary(
+            binary, override_operator=operators.match_op))
 
     def visit_binary(self, binary, override_operator=None, **kw):
         # don't allow "? = ?" to render
@@ -1084,7 +1081,7 @@ class SQLCompiler(Compiled):
         escape = binary.modifiers.get("escape", None)
 
         # TODO: use ternary here, not "and"/ "or"
-        return '%s LIKE %s' % (
+        return '{0!s} LIKE {1!s}'.format(
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -1095,7 +1092,7 @@ class SQLCompiler(Compiled):
 
     def visit_notlike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
-        return '%s NOT LIKE %s' % (
+        return '{0!s} NOT LIKE {1!s}'.format(
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -1106,7 +1103,7 @@ class SQLCompiler(Compiled):
 
     def visit_ilike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
-        return 'lower(%s) LIKE lower(%s)' % (
+        return 'lower({0!s}) LIKE lower({1!s})'.format(
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -1117,7 +1114,7 @@ class SQLCompiler(Compiled):
 
     def visit_notilike_op_binary(self, binary, operator, **kw):
         escape = binary.modifiers.get("escape", None)
-        return 'lower(%s) NOT LIKE lower(%s)' % (
+        return 'lower({0!s}) NOT LIKE lower({1!s})'.format(
             binary.left._compiler_dispatch(self, **kw),
             binary.right._compiler_dispatch(self, **kw)) \
             + (
@@ -1205,7 +1202,7 @@ class SQLCompiler(Compiled):
             return processor(value)
         else:
             raise NotImplementedError(
-                "Don't know how to literal-quote value %r" % value)
+                "Don't know how to literal-quote value {0!r}".format(value))
 
     def _truncate_bindparam(self, bindparam):
         if bindparam in self.bind_names:
@@ -1308,9 +1305,9 @@ class SQLCompiler(Compiled):
                               util.unique_list(col_source.inner_columns)
                               if c is not None]
 
-                text += "(%s)" % (", ".join(
+                text += "({0!s})".format((", ".join(
                     self.preparer.format_column(ident)
-                    for ident in recur_cols))
+                    for ident in recur_cols)))
 
             if self.positional:
                 kwargs['positional_names'] = self.cte_positional[cte] = []
@@ -1361,16 +1358,16 @@ class SQLCompiler(Compiled):
 
     def visit_lateral(self, lateral, **kw):
         kw['lateral'] = True
-        return "LATERAL %s" % self.visit_alias(lateral, **kw)
+        return "LATERAL {0!s}".format(self.visit_alias(lateral, **kw))
 
     def visit_tablesample(self, tablesample, asfrom=False, **kw):
-        text = "%s TABLESAMPLE %s" % (
+        text = "{0!s} TABLESAMPLE {1!s}".format(
             self.visit_alias(tablesample, asfrom=True, **kw),
             tablesample._get_method()._compiler_dispatch(self, **kw))
 
         if tablesample.seed is not None:
-            text += " REPEATABLE (%s)" % (
-                tablesample.seed._compiler_dispatch(self, **kw))
+            text += " REPEATABLE ({0!s})".format((
+                tablesample.seed._compiler_dispatch(self, **kw)))
 
         return text
 
@@ -1978,8 +1975,8 @@ class SQLCompiler(Compiled):
         text += table_text
 
         if crud_params_single or not supports_default_values:
-            text += " (%s)" % ', '.join([preparer.format_column(c[0])
-                                         for c in crud_params_single])
+            text += " ({0!s})".format(', '.join([preparer.format_column(c[0])
+                                         for c in crud_params_single]))
 
         if self.returning or insert_stmt._returning:
             returning_clause = self.returning_clause(
@@ -1991,21 +1988,21 @@ class SQLCompiler(Compiled):
             returning_clause = None
 
         if insert_stmt.select is not None:
-            text += " %s" % self.process(self._insert_from_select, **kw)
+            text += " {0!s}".format(self.process(self._insert_from_select, **kw))
         elif not crud_params and supports_default_values:
             text += " DEFAULT VALUES"
         elif insert_stmt._has_multi_parameters:
-            text += " VALUES %s" % (
+            text += " VALUES {0!s}".format((
                 ", ".join(
-                    "(%s)" % (
+                    "({0!s})".format((
                         ', '.join(c[1] for c in crud_param_set)
-                    )
+                    ))
                     for crud_param_set in crud_params
                 )
-            )
+            ))
         else:
-            text += " VALUES (%s)" % \
-                ', '.join([c[1] for c in crud_params])
+            text += " VALUES ({0!s})".format( \
+                ', '.join([c[1] for c in crud_params]))
 
         if insert_stmt._post_values_clause is not None:
             post_values_clause = self.process(
@@ -2187,15 +2184,15 @@ class SQLCompiler(Compiled):
             return text
 
     def visit_savepoint(self, savepoint_stmt):
-        return "SAVEPOINT %s" % self.preparer.format_savepoint(savepoint_stmt)
+        return "SAVEPOINT {0!s}".format(self.preparer.format_savepoint(savepoint_stmt))
 
     def visit_rollback_to_savepoint(self, savepoint_stmt):
-        return "ROLLBACK TO SAVEPOINT %s" % \
-            self.preparer.format_savepoint(savepoint_stmt)
+        return "ROLLBACK TO SAVEPOINT {0!s}".format( \
+            self.preparer.format_savepoint(savepoint_stmt))
 
     def visit_release_savepoint(self, savepoint_stmt):
-        return "RELEASE SAVEPOINT %s" % \
-            self.preparer.format_savepoint(savepoint_stmt)
+        return "RELEASE SAVEPOINT {0!s}".format( \
+            self.preparer.format_savepoint(savepoint_stmt))
 
 
 class StrSQLCompiler(SQLCompiler):
@@ -2210,7 +2207,7 @@ class StrSQLCompiler(SQLCompiler):
         return "<name unknown>"
 
     def visit_getitem_binary(self, binary, operator, **kw):
-        return "%s[%s]" % (
+        return "{0!s}[{1!s}]".format(
             self.process(binary.left, **kw),
             self.process(binary.right, **kw)
         )
@@ -2311,7 +2308,7 @@ class DDLCompiler(Compiled):
         if const:
             text += separator + "\t" + const
 
-        text += "\n)%s\n\n" % self.post_create_table(table)
+        text += "\n){0!s}\n\n".format(self.post_create_table(table))
         return text
 
     def visit_create_column(self, create, first_pk=False):
@@ -2383,8 +2380,7 @@ class DDLCompiler(Compiled):
         text = "CREATE "
         if index.unique:
             text += "UNIQUE "
-        text += "INDEX %s ON %s (%s)" \
-            % (
+        text += "INDEX {0!s} ON {1!s} ({2!s})".format(
                 self._prepared_index_name(index,
                                           include_schema=include_schema),
                 preparer.format_table(index.table,
@@ -2428,22 +2424,22 @@ class DDLCompiler(Compiled):
         return index_name
 
     def visit_add_constraint(self, create):
-        return "ALTER TABLE %s ADD %s" % (
+        return "ALTER TABLE {0!s} ADD {1!s}".format(
             self.preparer.format_table(create.element.table),
             self.process(create.element)
         )
 
     def visit_create_sequence(self, create):
-        text = "CREATE SEQUENCE %s" % \
-            self.preparer.format_sequence(create.element)
+        text = "CREATE SEQUENCE {0!s}".format( \
+            self.preparer.format_sequence(create.element))
         if create.element.increment is not None:
-            text += " INCREMENT BY %d" % create.element.increment
+            text += " INCREMENT BY {0:d}".format(create.element.increment)
         if create.element.start is not None:
-            text += " START WITH %d" % create.element.start
+            text += " START WITH {0:d}".format(create.element.start)
         if create.element.minvalue is not None:
-            text += " MINVALUE %d" % create.element.minvalue
+            text += " MINVALUE {0:d}".format(create.element.minvalue)
         if create.element.maxvalue is not None:
-            text += " MAXVALUE %d" % create.element.maxvalue
+            text += " MAXVALUE {0:d}".format(create.element.maxvalue)
         if create.element.nominvalue is not None:
             text += " NO MINVALUE"
         if create.element.nomaxvalue is not None:
@@ -2453,8 +2449,8 @@ class DDLCompiler(Compiled):
         return text
 
     def visit_drop_sequence(self, drop):
-        return "DROP SEQUENCE %s" % \
-            self.preparer.format_sequence(drop.element)
+        return "DROP SEQUENCE {0!s}".format( \
+            self.preparer.format_sequence(drop.element))
 
     def visit_drop_constraint(self, drop):
         constraint = drop.element
@@ -2467,7 +2463,7 @@ class DDLCompiler(Compiled):
             raise exc.CompileError(
                 "Can't emit DROP CONSTRAINT for constraint %r; "
                 "it has no name" % drop.element)
-        return "ALTER TABLE %s DROP CONSTRAINT %s%s" % (
+        return "ALTER TABLE {0!s} DROP CONSTRAINT {1!s}{2!s}".format(
             self.preparer.format_table(drop.element.table),
             formatted_name,
             drop.cascade and " CASCADE" or ""
@@ -2494,7 +2490,7 @@ class DDLCompiler(Compiled):
     def get_column_default_string(self, column):
         if isinstance(column.server_default, schema.DefaultClause):
             if isinstance(column.server_default.arg, util.string_types):
-                return "'%s'" % column.server_default.arg
+                return "'{0!s}'".format(column.server_default.arg)
             else:
                 return self.sql_compiler.process(
                     column.server_default.arg, literal_binds=True)
@@ -2506,10 +2502,10 @@ class DDLCompiler(Compiled):
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
             if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
-        text += "CHECK (%s)" % self.sql_compiler.process(constraint.sqltext,
+                text += "CONSTRAINT {0!s} ".format(formatted_name)
+        text += "CHECK ({0!s})".format(self.sql_compiler.process(constraint.sqltext,
                                                          include_table=False,
-                                                         literal_binds=True)
+                                                         literal_binds=True))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -2518,8 +2514,8 @@ class DDLCompiler(Compiled):
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
             if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
-        text += "CHECK (%s)" % constraint.sqltext
+                text += "CONSTRAINT {0!s} ".format(formatted_name)
+        text += "CHECK ({0!s})".format(constraint.sqltext)
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -2530,12 +2526,12 @@ class DDLCompiler(Compiled):
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
             if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
+                text += "CONSTRAINT {0!s} ".format(formatted_name)
         text += "PRIMARY KEY "
-        text += "(%s)" % ', '.join(self.preparer.quote(c.name)
+        text += "({0!s})".format(', '.join(self.preparer.quote(c.name)
                                    for c in (constraint.columns_autoinc_first
                                    if constraint._implicit_generated
-                                   else constraint.columns))
+                                   else constraint.columns)))
         text += self.define_constraint_deferrability(constraint)
         return text
 
@@ -2545,9 +2541,9 @@ class DDLCompiler(Compiled):
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
             if formatted_name is not None:
-                text += "CONSTRAINT %s " % formatted_name
+                text += "CONSTRAINT {0!s} ".format(formatted_name)
         remote_table = list(constraint.elements)[0].column.table
-        text += "FOREIGN KEY(%s) REFERENCES %s (%s)" % (
+        text += "FOREIGN KEY({0!s}) REFERENCES {1!s} ({2!s})".format(
             ', '.join(preparer.quote(f.parent.name)
                       for f in constraint.elements),
             self.define_constraint_remote_table(
@@ -2571,19 +2567,19 @@ class DDLCompiler(Compiled):
         text = ""
         if constraint.name is not None:
             formatted_name = self.preparer.format_constraint(constraint)
-            text += "CONSTRAINT %s " % formatted_name
-        text += "UNIQUE (%s)" % (
+            text += "CONSTRAINT {0!s} ".format(formatted_name)
+        text += "UNIQUE ({0!s})".format((
                 ', '.join(self.preparer.quote(c.name)
-                          for c in constraint))
+                          for c in constraint)))
         text += self.define_constraint_deferrability(constraint)
         return text
 
     def define_constraint_cascades(self, constraint):
         text = ""
         if constraint.ondelete is not None:
-            text += " ON DELETE %s" % constraint.ondelete
+            text += " ON DELETE {0!s}".format(constraint.ondelete)
         if constraint.onupdate is not None:
-            text += " ON UPDATE %s" % constraint.onupdate
+            text += " ON UPDATE {0!s}".format(constraint.onupdate)
         return text
 
     def define_constraint_deferrability(self, constraint):
@@ -2594,13 +2590,13 @@ class DDLCompiler(Compiled):
             else:
                 text += " NOT DEFERRABLE"
         if constraint.initially is not None:
-            text += " INITIALLY %s" % constraint.initially
+            text += " INITIALLY {0!s}".format(constraint.initially)
         return text
 
     def define_constraint_match(self, constraint):
         text = ""
         if constraint.match is not None:
-            text += " MATCH %s" % constraint.match
+            text += " MATCH {0!s}".format(constraint.match)
         return text
 
 
@@ -2616,23 +2612,23 @@ class GenericTypeCompiler(TypeCompiler):
         if type_.precision is None:
             return "NUMERIC"
         elif type_.scale is None:
-            return "NUMERIC(%(precision)s)" % \
-                {'precision': type_.precision}
+            return "NUMERIC({precision!s})".format(** \
+                {'precision': type_.precision})
         else:
-            return "NUMERIC(%(precision)s, %(scale)s)" % \
+            return "NUMERIC({precision!s}, {scale!s})".format(** \
                 {'precision': type_.precision,
-                 'scale': type_.scale}
+                 'scale': type_.scale})
 
     def visit_DECIMAL(self, type_, **kw):
         if type_.precision is None:
             return "DECIMAL"
         elif type_.scale is None:
-            return "DECIMAL(%(precision)s)" % \
-                {'precision': type_.precision}
+            return "DECIMAL({precision!s})".format(** \
+                {'precision': type_.precision})
         else:
-            return "DECIMAL(%(precision)s, %(scale)s)" % \
+            return "DECIMAL({precision!s}, {scale!s})".format(** \
                 {'precision': type_.precision,
-                 'scale': type_.scale}
+                 'scale': type_.scale})
 
     def visit_INTEGER(self, type_, **kw):
         return "INTEGER"
@@ -2665,9 +2661,9 @@ class GenericTypeCompiler(TypeCompiler):
 
         text = name
         if type_.length:
-            text += "(%d)" % type_.length
+            text += "({0:d})".format(type_.length)
         if type_.collation:
-            text += ' COLLATE "%s"' % type_.collation
+            text += ' COLLATE "{0!s}"'.format(type_.collation)
         return text
 
     def visit_CHAR(self, type_, **kw):
@@ -2689,10 +2685,10 @@ class GenericTypeCompiler(TypeCompiler):
         return "BLOB"
 
     def visit_BINARY(self, type_, **kw):
-        return "BINARY" + (type_.length and "(%d)" % type_.length or "")
+        return "BINARY" + (type_.length and "({0:d})".format(type_.length) or "")
 
     def visit_VARBINARY(self, type_, **kw):
-        return "VARBINARY" + (type_.length and "(%d)" % type_.length or "")
+        return "VARBINARY" + (type_.length and "({0:d})".format(type_.length) or "")
 
     def visit_BOOLEAN(self, type_, **kw):
         return "BOOLEAN"
@@ -2765,7 +2761,7 @@ class StrSQLTypeCompiler(GenericTypeCompiler):
             raise AttributeError(key)
 
     def _visit_unknown(self, type_, **kw):
-        return "%s" % type_.__class__.__name__
+        return "{0!s}".format(type_.__class__.__name__)
 
 
 class IdentifierPreparer(object):

--- a/lib/sqlalchemy/sql/crud.py
+++ b/lib/sqlalchemy/sql/crud.py
@@ -142,8 +142,8 @@ def _get_crud_params(compiler, stmt, **kw):
         ).difference(check_columns)
         if check:
             raise exc.CompileError(
-                "Unconsumed column names: %s" %
-                (", ".join("%s" % c for c in check))
+                "Unconsumed column names: {0!s}".format(
+                (", ".join("{0!s}".format(c) for c in check)))
             )
 
     if stmt._has_multi_parameters:
@@ -190,7 +190,7 @@ def _key_getters_for_crud_column(compiler, stmt):
 
         def _col_bind_name(col):
             if col.table in _et:
-                return "%s_%s" % (col.table.name, col.key)
+                return "{0!s}_{1!s}".format(col.table.name, col.key)
             else:
                 return col.key
 
@@ -317,7 +317,7 @@ def _append_param_parameter(
             compiler, c, value, required=value is REQUIRED,
             name=_col_bind_name(c)
             if not stmt._has_multi_parameters
-            else "%s_0" % _col_bind_name(c),
+            else "{0!s}_0".format(_col_bind_name(c)),
             **kw
         )
     else:
@@ -396,7 +396,7 @@ def _create_update_prefetch_bind_param(compiler, c, process=True, name=None):
 
 class _multiparam_column(elements.ColumnElement):
     def __init__(self, original, index):
-        self.key = "%s_%d" % (original.key, index + 1)
+        self.key = "{0!s}_{1:d}".format(original.key, index + 1)
         self.original = original
         self.default = original.default
         self.type = original.type
@@ -603,7 +603,7 @@ def _extend_values_for_multiparams(compiler, stmt, values, kw):
                 c,
                 (_create_bind_param(
                     compiler, c, row[c.key],
-                    name="%s_%d" % (c.key, i + 1)
+                    name="{0!s}_{1:d}".format(c.key, i + 1)
                 ) if elements._is_literal(row[c.key])
                     else compiler.process(
                         row[c.key].self_group(), **kw))

--- a/lib/sqlalchemy/sql/ddl.py
+++ b/lib/sqlalchemy/sql/ddl.py
@@ -375,8 +375,8 @@ class DDL(DDLElement):
 
         if not isinstance(statement, util.string_types):
             raise exc.ArgumentError(
-                "Expected a string or unicode SQL statement, got '%r'" %
-                statement)
+                "Expected a string or unicode SQL statement, got '{0!r}'".format(
+                statement))
 
         self.statement = statement
         self.context = context or {}
@@ -386,10 +386,10 @@ class DDL(DDLElement):
         self._bind = bind
 
     def __repr__(self):
-        return '<%s@%s; %s>' % (
+        return '<{0!s}@{1!s}; {2!s}>'.format(
             type(self).__name__, id(self),
             ', '.join([repr(self.statement)] +
-                      ['%s=%r' % (key, getattr(self, key))
+                      ['{0!s}={1!r}'.format(key, getattr(self, key))
                        for key in ('on', 'context')
                        if getattr(self, key)]))
 

--- a/lib/sqlalchemy/sql/elements.py
+++ b/lib/sqlalchemy/sql/elements.py
@@ -487,7 +487,7 @@ class ClauseElement(Visitable):
         if friendly is None:
             return object.__repr__(self)
         else:
-            return '<%s.%s at 0x%x; %s>' % (
+            return '<{0!s}.{1!s} at 0x{2:x}; {3!s}>'.format(
                 self.__module__, self.__class__.__name__, id(self), friendly)
 
 
@@ -676,7 +676,7 @@ class ColumnElement(operators.ColumnOperators, ClauseElement):
             return getattr(self.comparator, key)
         except AttributeError:
             raise AttributeError(
-                'Neither %r object nor %r object has an attribute %r' % (
+                'Neither {0!r} object nor {1!r} object has an attribute {2!r}'.format(
                     type(self).__name__,
                     type(self.comparator).__name__,
                     key)
@@ -830,7 +830,7 @@ class ColumnElement(operators.ColumnOperators, ClauseElement):
             self = self._is_clone_of
 
         return _anonymous_label(
-            '%%(%d %s)s' % (id(self), getattr(self, 'name', 'anon'))
+            '%({0:d} {1!s})s'.format(id(self), getattr(self, 'name', 'anon'))
         )
 
 
@@ -1067,11 +1067,10 @@ class BindParameter(ColumnElement):
             key = quoted_name(key, quote)
 
         if unique:
-            self.key = _anonymous_label('%%(%d %s)s' % (id(self), key
+            self.key = _anonymous_label('%({0:d} {1!s})s'.format(id(self), key
                                                         or 'param'))
         else:
-            self.key = key or _anonymous_label('%%(%d param)s'
-                                               % id(self))
+            self.key = key or _anonymous_label('%({0:d} param)s'.format(id(self)))
 
         # identifying key that won't change across
         # clones, used to identify the bind's logical
@@ -1129,7 +1128,7 @@ class BindParameter(ColumnElement):
     def _clone(self):
         c = ClauseElement._clone(self)
         if self.unique:
-            c.key = _anonymous_label('%%(%d %s)s' % (id(c), c._orig_key
+            c.key = _anonymous_label('%({0:d} {1!s})s'.format(id(c), c._orig_key
                                                      or 'param'))
         return c
 
@@ -1137,7 +1136,7 @@ class BindParameter(ColumnElement):
         if not self.unique:
             self.unique = True
             self.key = _anonymous_label(
-                '%%(%d %s)s' % (id(self), self._orig_key or 'param'))
+                '%({0:d} {1!s})s'.format(id(self), self._orig_key or 'param'))
 
     def compare(self, other, **kw):
         """Compare this :class:`BindParameter` to the given
@@ -1159,7 +1158,7 @@ class BindParameter(ColumnElement):
         return d
 
     def __repr__(self):
-        return 'BindParameter(%r, %r, type_=%r)' % (self.key,
+        return 'BindParameter({0!r}, {1!r}, type_={2!r})'.format(self.key,
                                                     self.value, self.type)
 
 
@@ -1230,7 +1229,7 @@ class TextClause(Executable, ClauseElement):
 
         def repl(m):
             self._bindparams[m.group(1)] = BindParameter(m.group(1))
-            return ':%s' % m.group(1)
+            return ':{0!s}'.format(m.group(1))
 
         # scan the string and search for bind parameter names, add them
         # to the list of bindparams
@@ -3520,7 +3519,7 @@ class Label(ColumnElement):
             self._resolve_label = self.name
         else:
             self.name = _anonymous_label(
-                '%%(%d %s)s' % (id(self), getattr(element, 'name', 'anon'))
+                '%({0:d} {1!s})s'.format(id(self), getattr(element, 'name', 'anon'))
             )
 
         self.key = self._label = self._key_label = self.name
@@ -3575,7 +3574,7 @@ class Label(ColumnElement):
         self.__dict__.pop('_allow_label_resolve', None)
         if anonymize_labels:
             self.name = self._resolve_label = _anonymous_label(
-                '%%(%d %s)s' % (
+                '%({0:d} {1!s})s'.format(
                     id(self), getattr(self.element, 'name', 'anon'))
             )
             self.key = self._label = self._key_label = self.name
@@ -3949,7 +3948,7 @@ class quoted_name(util.MemoizedSlots, util.text_type):
         backslashed = self.encode('ascii', 'backslashreplace')
         if not util.py2k:
             backslashed = backslashed.decode('ascii')
-        return "'%s'" % backslashed
+        return "'{0!s}'".format(backslashed)
 
 
 class _truncated_label(quoted_name):
@@ -4099,7 +4098,7 @@ def _string_or_unprintable(element):
         try:
             return str(element)
         except Exception:
-            return "unprintable element %r" % element
+            return "unprintable element {0!r}".format(element)
 
 
 def _expand_cloned(elements):

--- a/lib/sqlalchemy/sql/naming.py
+++ b/lib/sqlalchemy/sql/naming.py
@@ -75,8 +75,8 @@ class ConventionDict(object):
     def __getitem__(self, key):
         if key in self.convention:
             return self.convention[key](self.const, self.table)
-        elif hasattr(self, '_key_%s' % key):
-            return getattr(self, '_key_%s' % key)()
+        elif hasattr(self, '_key_{0!s}'.format(key)):
+            return getattr(self, '_key_{0!s}'.format(key))()
         else:
             col_template = re.match(r".*_?column_(\d+)_.+", key)
             if col_template:

--- a/lib/sqlalchemy/sql/schema.py
+++ b/lib/sqlalchemy/sql/schema.py
@@ -423,7 +423,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         else:
             if mustexist:
                 raise exc.InvalidRequestError(
-                    "Table '%s' not defined" % (key))
+                    "Table '{0!s}' not defined".format((key)))
             table = object.__new__(cls)
             table.dispatch.before_parent_attach(table, metadata)
             metadata._add_table(name, schema, table)
@@ -477,7 +477,7 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         self.foreign_keys = set()
         self._extra_dependencies = set()
         if self.schema is not None:
-            self.fullname = "%s.%s" % (self.schema, self.name)
+            self.fullname = "{0!s}.{1!s}".format(self.schema, self.name)
         else:
             self.fullname = self.name
 
@@ -616,10 +616,10 @@ class Table(DialectKWArgs, SchemaItem, TableClause):
         return _get_table_key(self.name, self.schema)
 
     def __repr__(self):
-        return "Table(%s)" % ', '.join(
+        return "Table({0!s})".format(', '.join(
             [repr(self.name)] + [repr(self.metadata)] +
             [repr(x) for x in self.columns] +
-            ["%s=%s" % (k, repr(getattr(self, k))) for k in ['schema']])
+            ["{0!s}={1!s}".format(k, repr(getattr(self, k))) for k in ['schema']]))
 
     def __str__(self):
         return _get_table_key(self.description, self.schema)
@@ -1270,13 +1270,13 @@ class Column(SchemaItem, ColumnClause):
             kwarg.append('default')
         if self.server_default:
             kwarg.append('server_default')
-        return "Column(%s)" % ', '.join(
+        return "Column({0!s})".format(', '.join(
             [repr(self.name)] + [repr(self.type)] +
             [repr(x) for x in self.foreign_keys if x is not None] +
             [repr(x) for x in self.constraints] +
-            [(self.table is not None and "table=<%s>" %
-              self.table.description or "table=None")] +
-            ["%s=%s" % (k, repr(getattr(self, k))) for k in kwarg])
+            [(self.table is not None and "table=<{0!s}>".format(
+              self.table.description) or "table=None")] +
+            ["{0!s}={1!s}".format(k, repr(getattr(self, k))) for k in kwarg]))
 
     def _set_parent(self, table):
         if not self.name:
@@ -1289,7 +1289,7 @@ class Column(SchemaItem, ColumnClause):
         existing = getattr(self, 'table', None)
         if existing is not None and existing is not table:
             raise exc.ArgumentError(
-                "Column object '%s' already assigned to Table '%s'" % (
+                "Column object '{0!s}' already assigned to Table '{1!s}'".format(
                     self.key,
                     existing.description
                 ))
@@ -1599,7 +1599,7 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         self._unvalidated_dialect_kw = dialect_kw
 
     def __repr__(self):
-        return "ForeignKey(%r)" % self._get_colspec()
+        return "ForeignKey({0!r})".format(self._get_colspec())
 
     def copy(self, schema=None):
         """Produce a copy of this :class:`.ForeignKey` object.
@@ -1643,15 +1643,15 @@ class ForeignKey(DialectKWArgs, SchemaItem):
             _schema, tname, colname = self._column_tokens
             if table_name is not None:
                 tname = table_name
-            return "%s.%s.%s" % (schema, tname, colname)
+            return "{0!s}.{1!s}.{2!s}".format(schema, tname, colname)
         elif table_name:
             schema, tname, colname = self._column_tokens
             if schema:
-                return "%s.%s.%s" % (schema, table_name, colname)
+                return "{0!s}.{1!s}.{2!s}".format(schema, table_name, colname)
             else:
-                return "%s.%s" % (table_name, colname)
+                return "{0!s}.{1!s}".format(table_name, colname)
         elif self._table_column is not None:
-            return "%s.%s" % (
+            return "{0!s}.{1!s}".format(
                 self._table_column.table.fullname, self._table_column.key)
         else:
             return self._colspec
@@ -1696,8 +1696,8 @@ class ForeignKey(DialectKWArgs, SchemaItem):
         m = self._get_colspec().split('.')
         if m is None:
             raise exc.ArgumentError(
-                "Invalid foreign key column specification: %s" %
-                self._colspec)
+                "Invalid foreign key column specification: {0!s}".format(
+                self._colspec))
         if (len(m) == 1):
             tname = m.pop()
             colname = None
@@ -2053,7 +2053,7 @@ class ColumnDefault(DefaultGenerator):
     __visit_name__ = property(_visit_name)
 
     def __repr__(self):
-        return "ColumnDefault(%r)" % self.arg
+        return "ColumnDefault({0!r})".format(self.arg)
 
 
 class Sequence(DefaultGenerator):
@@ -2365,8 +2365,7 @@ class DefaultClause(FetchedValue):
         self.reflected = _reflected
 
     def __repr__(self):
-        return "DefaultClause(%r, for_update=%r)" % \
-            (self.arg, self.for_update)
+        return "DefaultClause({0!r}, for_update={1!r})".format(self.arg, self.for_update)
 
 
 class PassiveDefault(DefaultClause):
@@ -2563,8 +2562,7 @@ class ColumnCollectionMixin(object):
             others = [c for c in columns[1:] if c.table is not table]
             if others:
                 raise exc.ArgumentError(
-                    "Column(s) %s are not part of table '%s'." %
-                    (", ".join("'%s'" % c for c in others),
+                    "Column(s) {0!s} are not part of table '{1!s}'.".format(", ".join("'{0!s}'".format(c) for c in others),
                         table.description)
                 )
 
@@ -3052,9 +3050,9 @@ class PrimaryKeyConstraint(ColumnCollectionConstraint):
                 "may become an exception in a future release" %
                 (
                     table.name,
-                    ", ".join("'%s'" % c.name for c in table_pks),
-                    ", ".join("'%s'" % c.name for c in self.columns),
-                    ", ".join("'%s'" % c.name for c in self.columns)
+                    ", ".join("'{0!s}'".format(c.name) for c in table_pks),
+                    ", ".join("'{0!s}'".format(c.name) for c in self.columns),
+                    ", ".join("'{0!s}'".format(c.name) for c in self.columns)
                 )
             )
             table_pks[:] = []
@@ -3363,12 +3361,12 @@ class Index(DialectKWArgs, ColumnCollectionMixin, SchemaItem):
         bind._run_visitor(ddl.SchemaDropper, self)
 
     def __repr__(self):
-        return 'Index(%s)' % (
+        return 'Index({0!s})'.format((
             ", ".join(
                 [repr(self.name)] +
                 [repr(e) for e in self.expressions] +
                 (self.unique and ["unique=True"] or [])
-            ))
+            )))
 
 
 DEFAULT_NAMING_CONVENTION = util.immutabledict({
@@ -3550,7 +3548,7 @@ class MetaData(SchemaItem):
     """
 
     def __repr__(self):
-        return 'MetaData(bind=%r)' % self.bind
+        return 'MetaData(bind={0!r})'.format(self.bind)
 
     def __contains__(self, table_or_key):
         if not isinstance(table_or_key, util.string_types):
@@ -3763,7 +3761,7 @@ class MetaData(SchemaItem):
                 )
 
             if schema is not None:
-                available_w_schema = util.OrderedSet(["%s.%s" % (schema, name)
+                available_w_schema = util.OrderedSet(["{0!s}.{1!s}".format(schema, name)
                                                       for name in available])
             else:
                 available_w_schema = available
@@ -3782,7 +3780,7 @@ class MetaData(SchemaItem):
             else:
                 missing = [name for name in only if name not in available]
                 if missing:
-                    s = schema and (" schema '%s'" % schema) or ''
+                    s = schema and (" schema '{0!s}'".format(schema)) or ''
                     raise exc.InvalidRequestError(
                         'Could not reflect: requested table(s) not available '
                         'in %s%s: (%s)' %
@@ -3952,7 +3950,7 @@ class _SchemaTranslateMap(object):
                 return effective_schema
             self.__call__ = schema_for_object
             self.hash_key = ";".join(
-                "%s=%s" % (k, map_[k])
+                "{0!s}={1!s}".format(k, map_[k])
                 for k in sorted(map_, key=str)
             )
             self.is_default = False

--- a/lib/sqlalchemy/sql/selectable.py
+++ b/lib/sqlalchemy/sql/selectable.py
@@ -267,8 +267,8 @@ class HasPrefixes(object):
         """
         dialect = kw.pop('dialect', None)
         if kw:
-            raise exc.ArgumentError("Unsupported argument(s): %s" %
-                                    ",".join(kw))
+            raise exc.ArgumentError("Unsupported argument(s): {0!s}".format(
+                                    ",".join(kw)))
         self._setup_prefixes(expr, dialect)
 
     def _setup_prefixes(self, prefixes, dialect=None):
@@ -303,8 +303,8 @@ class HasSuffixes(object):
         """
         dialect = kw.pop('dialect', None)
         if kw:
-            raise exc.ArgumentError("Unsupported argument(s): %s" %
-                                    ",".join(kw))
+            raise exc.ArgumentError("Unsupported argument(s): {0!s}".format(
+                                    ",".join(kw)))
         self._setup_suffixes(expr, dialect)
 
     def _setup_suffixes(self, suffixes, dialect=None):
@@ -873,7 +873,7 @@ class Join(FromClause):
 
     @property
     def description(self):
-        return "Join object on %s(%d) and %s(%d)" % (
+        return "Join object on {0!s}({1:d}) and {2!s}({3:d})".format(
             self.left.description,
             id(self.left),
             self.right.description,
@@ -1234,7 +1234,7 @@ class Alias(FromClause):
         if name is None:
             if self.original.named_with_column:
                 name = getattr(self.original, 'name', None)
-            name = _anonymous_label('%%(%d %s)s' % (id(self), name
+            name = _anonymous_label('%({0:d} {1!s})s'.format(id(self), name
                                                     or 'anon'))
         self.name = name
 
@@ -1823,7 +1823,7 @@ class ForUpdateArg(ClauseElement):
         elif arg == 'read_nowait':
             read = nowait = True
         elif arg is not True:
-            raise exc.ArgumentError("Unknown for_update argument: %r" % arg)
+            raise exc.ArgumentError("Unknown for_update argument: {0!r}".format(arg))
 
         return ForUpdateArg(read=read, nowait=nowait)
 

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -203,7 +203,7 @@ class String(Concatenable, TypeEngine):
     def literal_processor(self, dialect):
         def process(value):
             value = value.replace("'", "''")
-            return "'%s'" % value
+            return "'{0!s}'".format(value)
         return process
 
     def bind_processor(self, dialect):
@@ -848,7 +848,7 @@ class _Binary(TypeEngine):
     def literal_processor(self, dialect):
         def process(value):
             value = value.decode(dialect.encoding).replace("'", "''")
-            return "'%s'" % value
+            return "'{0!s}'".format(value)
         return process
 
     @property
@@ -1283,14 +1283,14 @@ class Enum(String, SchemaType):
                 return elem
             else:
                 raise LookupError(
-                    '"%s" is not among the defined enum values' % elem)
+                    '"{0!s}" is not among the defined enum values'.format(elem))
 
     def _object_value_for_elem(self, elem):
         try:
             return self._object_lookup[elem]
         except KeyError:
             raise LookupError(
-                '"%s" is not among the defined enum values' % elem)
+                '"{0!s}" is not among the defined enum values'.format(elem))
 
     def __repr__(self):
         return util.generic_repr(self,
@@ -2433,7 +2433,7 @@ def _resolve_value_to_type(value):
                 insp.__class__ in inspection._registrars
         ):
             raise exc.ArgumentError(
-                "Object %r is not legal as a SQL literal value" % value)
+                "Object {0!r} is not legal as a SQL literal value".format(value))
         return NULLTYPE
     else:
         return _result_type

--- a/lib/sqlalchemy/sql/util.py
+++ b/lib/sqlalchemy/sql/util.py
@@ -284,7 +284,7 @@ def bind_values(clause):
 def _quote_ddl_expr(element):
     if isinstance(element, util.string_types):
         element = element.replace("'", "''")
-        return "'%s'" % element
+        return "'{0!s}'".format(element)
     else:
         return repr(element)
 
@@ -303,8 +303,7 @@ class _repr_base(object):
             segment_length = self.max_chars // 2
             rep = (
                 rep[0:segment_length] +
-                (" ... (%d characters truncated) ... "
-                 % (lenrep - self.max_chars)) +
+                (" ... ({0:d} characters truncated) ... ".format((lenrep - self.max_chars))) +
                 rep[-segment_length:]
             )
         return rep
@@ -321,7 +320,7 @@ class _repr_row(_repr_base):
 
     def __repr__(self):
         trunc = self.trunc
-        return "(%s%s)" % (
+        return "({0!s}{1!s})".format(
             ", ".join(trunc(value) for value in self.row),
             "," if len(self.row) == 1 else ""
         )
@@ -379,7 +378,7 @@ class _repr_params(_repr_base):
                 elem_type = self._DICT
             else:
                 assert False, \
-                    "Unknown parameter type %s" % (type(multi_params[0]))
+                    "Unknown parameter type {0!s}".format((type(multi_params[0])))
 
             elements = ", ".join(
                 self._repr_params(params, elem_type)
@@ -388,29 +387,29 @@ class _repr_params(_repr_base):
             elements = ""
 
         if typ == self._LIST:
-            return "[%s]" % elements
+            return "[{0!s}]".format(elements)
         else:
-            return "(%s)" % elements
+            return "({0!s})".format(elements)
 
     def _repr_params(self, params, typ):
         trunc = self.trunc
         if typ is self._DICT:
-            return "{%s}" % (
+            return "{{{0!s}}}".format((
                 ", ".join(
-                    "%r: %s" % (key, trunc(value))
+                    "{0!r}: {1!s}".format(key, trunc(value))
                     for key, value in params.items()
                 )
-            )
+            ))
         elif typ is self._TUPLE:
-            return "(%s%s)" % (
+            return "({0!s}{1!s})".format(
                 ", ".join(trunc(value) for value in params),
                 "," if len(params) == 1 else ""
 
             )
         else:
-            return "[%s]" % (
+            return "[{0!s}]".format((
                 ", ".join(trunc(value) for value in params)
-            )
+            ))
 
 
 def adapt_criterion_to_null(crit, nulls):

--- a/lib/sqlalchemy/sql/visitors.py
+++ b/lib/sqlalchemy/sql/visitors.py
@@ -70,7 +70,7 @@ def _generate_dispatch(cls):
             # There is an optimization opportunity here because the
             # the string name of the class's __visit_name__ is known at
             # this early stage (import time) so it can be pre-constructed.
-            getter = operator.attrgetter("visit_%s" % visit_name)
+            getter = operator.attrgetter("visit_{0!s}".format(visit_name))
 
             def _compiler_dispatch(self, visitor, **kw):
                 try:
@@ -84,7 +84,7 @@ def _generate_dispatch(cls):
             # __visit_name__ is not yet a string. As a result, the visit
             # string has to be recalculated with each compilation.
             def _compiler_dispatch(self, visitor, **kw):
-                visit_attr = 'visit_%s' % self.__visit_name__
+                visit_attr = 'visit_{0!s}'.format(self.__visit_name__)
                 try:
                     meth = getattr(visitor, visit_attr)
                 except AttributeError:
@@ -116,7 +116,7 @@ class ClauseVisitor(object):
 
     def traverse_single(self, obj, **kw):
         for v in self._visitor_iterator:
-            meth = getattr(v, "visit_%s" % obj.__visit_name__, None)
+            meth = getattr(v, "visit_{0!s}".format(obj.__visit_name__), None)
             if meth:
                 return meth(obj, **kw)
 

--- a/lib/sqlalchemy/testing/assertions.py
+++ b/lib/sqlalchemy/testing/assertions.py
@@ -148,8 +148,8 @@ def _expect_warnings(exc_cls, messages, regex=True, assert_=True):
         yield
 
     if assert_:
-        assert not seen, "Warnings were not seen: %s" % \
-            ", ".join("%r" % (s.pattern if regex else s) for s in seen)
+        assert not seen, "Warnings were not seen: {0!s}".format( \
+            ", ".join("{0!r}".format((s.pattern if regex else s)) for s in seen))
 
 
 def global_cleanup_assertions():
@@ -179,8 +179,7 @@ def _assert_no_stray_pool_connections():
         # OK, let's be somewhat forgiving.
         _STRAY_CONNECTION_FAILURES += 1
 
-        print("Encountered a stray connection in test cleanup: %s"
-              % str(pool._refs))
+        print("Encountered a stray connection in test cleanup: {0!s}".format(str(pool._refs)))
         # then do a real GC sweep.   We shouldn't even be here
         # so a single sweep should really be doing it, otherwise
         # there's probably a real unreachable cycle somewhere.
@@ -206,22 +205,22 @@ def _assert_no_stray_pool_connections():
 
 
 def eq_regex(a, b, msg=None):
-    assert re.match(b, a), msg or "%r !~ %r" % (a, b)
+    assert re.match(b, a), msg or "{0!r} !~ {1!r}".format(a, b)
 
 
 def eq_(a, b, msg=None):
     """Assert a == b, with repr messaging on failure."""
-    assert a == b, msg or "%r != %r" % (a, b)
+    assert a == b, msg or "{0!r} != {1!r}".format(a, b)
 
 
 def ne_(a, b, msg=None):
     """Assert a != b, with repr messaging on failure."""
-    assert a != b, msg or "%r == %r" % (a, b)
+    assert a != b, msg or "{0!r} == {1!r}".format(a, b)
 
 
 def le_(a, b, msg=None):
     """Assert a <= b, with repr messaging on failure."""
-    assert a <= b, msg or "%r != %r" % (a, b)
+    assert a <= b, msg or "{0!r} != {1!r}".format(a, b)
 
 
 def is_true(a, msg=None):
@@ -234,27 +233,27 @@ def is_false(a, msg=None):
 
 def is_(a, b, msg=None):
     """Assert a is b, with repr messaging on failure."""
-    assert a is b, msg or "%r is not %r" % (a, b)
+    assert a is b, msg or "{0!r} is not {1!r}".format(a, b)
 
 
 def is_not_(a, b, msg=None):
     """Assert a is not b, with repr messaging on failure."""
-    assert a is not b, msg or "%r is %r" % (a, b)
+    assert a is not b, msg or "{0!r} is {1!r}".format(a, b)
 
 
 def in_(a, b, msg=None):
     """Assert a in b, with repr messaging on failure."""
-    assert a in b, msg or "%r not in %r" % (a, b)
+    assert a in b, msg or "{0!r} not in {1!r}".format(a, b)
 
 
 def not_in_(a, b, msg=None):
     """Assert a in not b, with repr messaging on failure."""
-    assert a not in b, msg or "%r is in %r" % (a, b)
+    assert a not in b, msg or "{0!r} is in {1!r}".format(a, b)
 
 
 def startswith_(a, fragment, msg=None):
     """Assert a.startswith(fragment), with repr messaging on failure."""
-    assert a.startswith(fragment), msg or "%r does not start with %r" % (
+    assert a.startswith(fragment), msg or "{0!r} does not start with {1!r}".format(
         a, fragment)
 
 
@@ -264,7 +263,7 @@ def eq_ignore_whitespace(a, b, msg=None):
     b = re.sub(r'^\s+?|\n', "", b)
     b = re.sub(r' {2,}', " ", b)
 
-    assert a == b, msg or "%r != %r" % (a, b)
+    assert a == b, msg or "{0!r} != {1!r}".format(a, b)
 
 
 def assert_raises(except_cls, callable_, *args, **kw):
@@ -284,7 +283,7 @@ def assert_raises_message(except_cls, msg, callable_, *args, **kwargs):
         assert False, "Callable did not raise an exception"
     except except_cls as e:
         assert re.search(
-            msg, util.text_type(e), re.UNICODE), "%r !~ %s" % (msg, e)
+            msg, util.text_type(e), re.UNICODE), "{0!r} !~ {1!s}".format(msg, e)
         print(util.text_type(e).encode('utf-8'))
 
 
@@ -352,7 +351,7 @@ class AssertsCompiledSQL(object):
 
         cc = re.sub(r'[\n\t]', '', util.text_type(c))
 
-        eq_(cc, result, "%r != %r on dialect %r" % (cc, result, dialect))
+        eq_(cc, result, "{0!r} != {1!r} on dialect {2!r}".format(cc, result, dialect))
 
         if checkparams is not None:
             eq_(c.construct_params(params), checkparams)
@@ -397,8 +396,7 @@ class ComparesTables(object):
 
     def assert_types_base(self, c1, c2):
         assert c1.type._compare_type_affinity(c2.type),\
-            "On column %r, type '%s' doesn't correspond to type '%s'" % \
-            (c1.name, c1.type, c2.type)
+            "On column {0!r}, type '{1!s}' doesn't correspond to type '{2!s}'".format(c1.name, c1.type, c2.type)
 
 
 class AssertsExecutionResults(object):
@@ -425,7 +423,7 @@ class AssertsExecutionResults(object):
                     self.assert_row(value[0], getattr(rowobj, key), value[1])
             else:
                 self.assert_(getattr(rowobj, key) == value,
-                             "attribute %s value %s does not match %s" % (
+                             "attribute {0!s} value {1!s} does not match {2!s}".format(
                              key, getattr(rowobj, key), value))
 
     def assert_unordered_result(self, result, cls, *expected):
@@ -444,11 +442,11 @@ class AssertsExecutionResults(object):
 
         for wrong in util.itertools_filterfalse(lambda o:
                                                 isinstance(o, cls), found):
-            fail('Unexpected type "%s", expected "%s"' % (
+            fail('Unexpected type "{0!s}", expected "{1!s}"'.format(
                 type(wrong).__name__, cls.__name__))
 
         if len(found) != len(expected):
-            fail('Unexpected object count "%s", expected "%s"' % (
+            fail('Unexpected object count "{0!s}", expected "{1!s}"'.format(
                 len(found), len(expected)))
 
         NOVALUE = object()
@@ -473,7 +471,7 @@ class AssertsExecutionResults(object):
                     break
             else:
                 fail(
-                    "Expected %s instance with attributes %s not found." % (
+                    "Expected {0!s} instance with attributes {1!s} not found.".format(
                         cls.__name__, repr(expected_item)))
         return True
 

--- a/lib/sqlalchemy/testing/assertsql.py
+++ b/lib/sqlalchemy/testing/assertsql.py
@@ -46,7 +46,7 @@ class CursorSQL(SQLMatchRule):
         if self.statement != stmt.statement or (
                 self.params is not None and self.params != stmt.parameters):
             self.errormessage = \
-                "Testing for exact SQL %s parameters %s received %s %s" % (
+                "Testing for exact SQL {0!s} parameters {1!s} received {2!s} {3!s}".format(
                     self.statement, self.params,
                     stmt.statement, stmt.parameters
                 )
@@ -256,8 +256,7 @@ class CountStatements(AssertRule):
 
     def no_more_statements(self):
         if self.count != self._statement_count:
-            assert False, 'desired statement count %d does not match %d' \
-                % (self.count, self._statement_count)
+            assert False, 'desired statement count {0:d} does not match {1:d}'.format(self.count, self._statement_count)
 
 
 class AllOf(AssertRule):

--- a/lib/sqlalchemy/testing/engines.py
+++ b/lib/sqlalchemy/testing/engines.py
@@ -152,7 +152,7 @@ def all_dialects(exclude=None):
         mod = getattr(d, name, None)
         if not mod:
             mod = getattr(__import__(
-                'sqlalchemy.databases.%s' % name).databases, name)
+                'sqlalchemy.databases.{0!s}'.format(name)).databases, name)
         yield mod.dialect()
 
 

--- a/lib/sqlalchemy/testing/entities.py
+++ b/lib/sqlalchemy/testing/entities.py
@@ -22,9 +22,9 @@ class BasicEntity(object):
             return object.__repr__(self)
         _repr_stack.add(id(self))
         try:
-            return "%s(%s)" % (
+            return "{0!s}({1!s})".format(
                 (self.__class__.__name__),
-                ', '.join(["%s=%r" % (key, getattr(self, key))
+                ', '.join(["{0!s}={1!r}".format(key, getattr(self, key))
                            for key in sorted(self.__dict__.keys())
                            if not key.startswith('_')]))
         finally:

--- a/lib/sqlalchemy/testing/exclusions.py
+++ b/lib/sqlalchemy/testing/exclusions.py
@@ -112,7 +112,7 @@ class compound(object):
     def _do(self, config, fn, *args, **kw):
         for skip in self.skips:
             if skip(config):
-                msg = "'%s' : %s" % (
+                msg = "'{0!s}' : {1!s}".format(
                     fn.__name__,
                     skip._as_string(config)
                 )
@@ -129,7 +129,7 @@ class compound(object):
     def _expect_failure(self, config, ex, name='block'):
         for fail in self.fails:
             if fail(config):
-                print(("%s failed as expected (%s): %s " % (
+                print(("{0!s} failed as expected ({1!s}): {2!s} ".format(
                     name, fail._as_string(config), str(ex))))
                 break
         else:
@@ -143,8 +143,7 @@ class compound(object):
                 break
         else:
             raise AssertionError(
-                "Unexpected success for '%s' (%s)" %
-                (
+                "Unexpected success for '{0!s}' ({1!s})".format(
                     name,
                     " and ".join(
                         fail._as_string(config)
@@ -201,7 +200,7 @@ class Predicate(object):
         elif util.callable(predicate):
             return LambdaPredicate(predicate, description)
         else:
-            assert False, "unknown predicate type: %s" % predicate
+            assert False, "unknown predicate type: {0!s}".format(predicate)
 
     def _format_description(self, config, negate=False):
         bool_ = self(config)
@@ -221,7 +220,7 @@ class Predicate(object):
 class BooleanPredicate(Predicate):
     def __init__(self, value, description=None):
         self.value = value
-        self.description = description or "boolean %s" % value
+        self.description = description or "boolean {0!s}".format(value)
 
     def __call__(self, config):
         return self.value
@@ -276,18 +275,18 @@ class SpecPredicate(Predicate):
             return self._format_description(config)
         elif self.op is None:
             if negate:
-                return "not %s" % self.db
+                return "not {0!s}".format(self.db)
             else:
-                return "%s" % self.db
+                return "{0!s}".format(self.db)
         else:
             if negate:
-                return "not %s %s %s" % (
+                return "not {0!s} {1!s} {2!s}".format(
                     self.db,
                     self.op,
                     self.spec
                 )
             else:
-                return "%s %s %s" % (
+                return "{0!s} {1!s} {2!s}".format(
                     self.db,
                     self.op,
                     self.spec

--- a/lib/sqlalchemy/testing/fixtures.py
+++ b/lib/sqlalchemy/testing/fixtures.py
@@ -140,7 +140,7 @@ class TablesTest(TestBase):
                         conn.execute(table.delete())
                     except sa.exc.DBAPIError as ex:
                         util.print_(
-                            ("Error emptying table %s: %r" % (table, ex)),
+                            ("Error emptying table {0!s}: {1!r}".format(table, ex)),
                             file=sys.stderr)
 
     def setup(self):

--- a/lib/sqlalchemy/testing/pickleable.py
+++ b/lib/sqlalchemy/testing/pickleable.py
@@ -81,7 +81,7 @@ class Bar(object):
             other.y == self.y
 
     def __str__(self):
-        return "Bar(%d, %d)" % (self.x, self.y)
+        return "Bar({0:d}, {1:d})".format(self.x, self.y)
 
 
 class OldSchool:
@@ -110,7 +110,7 @@ class BarWithoutCompare(object):
         self.y = y
 
     def __str__(self):
-        return "Bar(%d, %d)" % (self.x, self.y)
+        return "Bar({0:d}, {1:d})".format(self.x, self.y)
 
 
 class NotComparable(object):

--- a/lib/sqlalchemy/testing/plugin/bootstrap.py
+++ b/lib/sqlalchemy/testing/plugin/bootstrap.py
@@ -25,7 +25,7 @@ to_bootstrap = locals()['to_bootstrap']
 
 
 def load_file_as_module(name):
-    path = os.path.join(os.path.dirname(bootstrap_file), "%s.py" % name)
+    path = os.path.join(os.path.dirname(bootstrap_file), "{0!s}.py".format(name))
     if sys.version_info >= (3, 3):
         from importlib import machinery
         mod = machinery.SourceFileLoader(name, path).load_module()
@@ -41,4 +41,4 @@ elif to_bootstrap == "nose":
     sys.modules["sqla_plugin_base"] = load_file_as_module("plugin_base")
     sys.modules["sqla_noseplugin"] = load_file_as_module("noseplugin")
 else:
-    raise Exception("unknown bootstrap: %s" % to_bootstrap)  # noqa
+    raise Exception("unknown bootstrap: {0!s}".format(to_bootstrap))  # noqa

--- a/lib/sqlalchemy/testing/plugin/plugin_base.py
+++ b/lib/sqlalchemy/testing/plugin/plugin_base.py
@@ -193,7 +193,7 @@ def _log(opt_str, value, parser):
 def _list_dbs(*args):
     print("Available --db options (use --dburi to override)")
     for macro in sorted(file_config.options('db')):
-        print("%20s\t%s" % (macro, file_config.get('db', macro)))
+        print("{0:20!s}\t{1!s}".format(macro, file_config.get('db', macro)))
     sys.exit(0)
 
 
@@ -408,12 +408,12 @@ def want_method(cls, fn):
 def generate_sub_tests(cls, module):
     if getattr(cls, '__backend__', False):
         for cfg in _possible_configs_for_cls(cls):
-            name = "%s_%s_%s" % (cls.__name__, cfg.db.name, cfg.db.driver)
+            name = "{0!s}_{1!s}_{2!s}".format(cls.__name__, cfg.db.name, cfg.db.driver)
             subcls = type(
                 name,
                 (cls, ),
                 {
-                    "__only_on__": ("%s+%s" % (cfg.db.name, cfg.db.driver)),
+                    "__only_on__": ("{0!s}+{1!s}".format(cfg.db.name, cfg.db.driver)),
                 }
             )
             setattr(module, name, subcls)
@@ -460,11 +460,11 @@ def before_test(test, test_module_name, test_class, test_name):
     # "test.aaa_profiling.test_compiler.CompileTest.test_update_whereclause"
     name = test_class.__name__
 
-    suffix = "_%s_%s" % (config.db.name, config.db.driver)
+    suffix = "_{0!s}_{1!s}".format(config.db.name, config.db.driver)
     if name.endswith(suffix):
         name = name[0:-(len(suffix))]
 
-    id_ = "%s.%s.%s" % (test_module_name, name, test_name)
+    id_ = "{0!s}.{1!s}.{2!s}".format(test_module_name, name, test_name)
 
     profiling._current_test = id_
 
@@ -523,19 +523,19 @@ def _do_skips(cls):
     if getattr(cls, '__skip_if__', False):
         for c in getattr(cls, '__skip_if__'):
             if c():
-                config.skip_test("'%s' skipped by %s" % (
+                config.skip_test("'{0!s}' skipped by {1!s}".format(
                     cls.__name__, c.__name__)
                 )
 
     if not all_configs:
         if getattr(cls, '__backend__', False):
-            msg = "'%s' unsupported for implementation '%s'" % (
+            msg = "'{0!s}' unsupported for implementation '{1!s}'".format(
                 cls.__name__, cls.__only_on__)
         else:
-            msg = "'%s' unsupported on any DB implementation %s%s" % (
+            msg = "'{0!s}' unsupported on any DB implementation {1!s}{2!s}".format(
                 cls.__name__,
                 ", ".join(
-                    "'%s(%s)+%s'" % (
+                    "'{0!s}({1!s})+{2!s}'".format(
                         config_obj.db.name,
                         ".".join(
                             str(dig) for dig in

--- a/lib/sqlalchemy/testing/plugin/pytestplugin.py
+++ b/lib/sqlalchemy/testing/plugin/pytestplugin.py
@@ -76,7 +76,7 @@ if has_xdist:
 
         plugin_base.memoize_important_follower_config(node.slaveinput)
 
-        node.slaveinput["follower_ident"] = "test_%s" % uuid.uuid4().hex[0:12]
+        node.slaveinput["follower_ident"] = "test_{0!s}".format(uuid.uuid4().hex[0:12])
         from sqlalchemy.testing import provision
         provision.create_follower_db(node.slaveinput["follower_ident"])
 

--- a/lib/sqlalchemy/testing/profiling.py
+++ b/lib/sqlalchemy/testing/profiling.py
@@ -170,17 +170,17 @@ class ProfileStatsFile(object):
         profile_f.close()
 
     def _write(self):
-        print(("Writing profile file %s" % self.fname))
+        print(("Writing profile file {0!s}".format(self.fname)))
         profile_f = open(self.fname, "w")
         profile_f.write(self._header())
         for test_key in sorted(self.data):
 
             per_fn = self.data[test_key]
-            profile_f.write("\n# TEST: %s\n\n" % test_key)
+            profile_f.write("\n# TEST: {0!s}\n\n".format(test_key))
             for platform_key in sorted(per_fn):
                 per_platform = per_fn[platform_key]
                 c = ",".join(str(count) for count in per_platform['counts'])
-                profile_f.write("%s %s %s\n" % (test_key, platform_key, c))
+                profile_f.write("{0!s} {1!s} {2!s}\n".format(test_key, platform_key, c))
         profile_f.close()
 
 
@@ -237,7 +237,7 @@ def count_functions(variance=0.05):
     else:
         line_no, expected_count = expected
 
-    print(("Pstats calls: %d Expected %s" % (
+    print(("Pstats calls: {0:d} Expected {1!s}".format(
         callcount,
         expected_count
     )

--- a/lib/sqlalchemy/testing/suite/test_reflection.py
+++ b/lib/sqlalchemy/testing/suite/test_reflection.py
@@ -67,8 +67,8 @@ class ComponentReflectionTest(fixtures.TablesTest):
                           Column('test1', sa.CHAR(5), nullable=False),
                           Column('test2', sa.Float(5), nullable=False),
                           Column('parent_user_id', sa.Integer,
-                                 sa.ForeignKey('%susers.user_id' %
-                                               schema_prefix)),
+                                 sa.ForeignKey('{0!s}users.user_id'.format(
+                                               schema_prefix))),
                           schema=schema,
                           test_needs_fk=True,
                           )
@@ -84,8 +84,8 @@ class ComponentReflectionTest(fixtures.TablesTest):
         Table("dingalings", metadata,
               Column('dingaling_id', sa.Integer, primary_key=True),
               Column('address_id', sa.Integer,
-                     sa.ForeignKey('%semail_addresses.address_id' %
-                                   schema_prefix)),
+                     sa.ForeignKey('{0!s}email_addresses.address_id'.format(
+                                   schema_prefix))),
               Column('data', sa.String(30)),
               schema=schema,
               test_needs_fk=True,
@@ -152,9 +152,9 @@ class ComponentReflectionTest(fixtures.TablesTest):
         for table_name in ('users', 'email_addresses'):
             fullname = table_name
             if schema:
-                fullname = "%s.%s" % (schema, table_name)
+                fullname = "{0!s}.{1!s}".format(schema, table_name)
             view_name = fullname + '_v'
-            query = "CREATE VIEW %s AS SELECT * FROM %s" % (
+            query = "CREATE VIEW {0!s} AS SELECT * FROM {1!s}".format(
                 view_name, fullname)
 
             event.listen(
@@ -165,7 +165,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
             event.listen(
                 metadata,
                 "before_drop",
-                DDL("DROP VIEW %s" % view_name)
+                DDL("DROP VIEW {0!s}".format(view_name))
             )
 
     @testing.requires.schema_reflection
@@ -295,8 +295,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
                                      sql_types.Time,
                                      sql_types.String,
                                      sql_types._Binary,
-                                 ])) > 0, '%s(%s), %s(%s)' %
-                             (col.name, col.type, cols[i]['name'], ctype))
+                                 ])) > 0, '{0!s}({1!s}), {2!s}({3!s})'.format(col.name, col.type, cols[i]['name'], ctype))
 
                 if not col.primary_key:
                     assert cols[i]['default'] is None
@@ -309,7 +308,7 @@ class ComponentReflectionTest(fixtures.TablesTest):
     def _type_round_trip(self, *types):
         t = Table('t', self.metadata,
                   *[
-                      Column('t%d' % i, type_)
+                      Column('t{0:d}'.format(i), type_)
                       for i, type_ in enumerate(types)
                   ]
                   )

--- a/lib/sqlalchemy/util/_collections.py
+++ b/lib/sqlalchemy/util/_collections.py
@@ -96,7 +96,7 @@ class KeyedTuple(AbstractKeyedTuple):
         return tuple([l for l in self._labels if l is not None])
 
     def __setattr__(self, key, value):
-        raise AttributeError("Can't set attribute: %s" % key)
+        raise AttributeError("Can't set attribute: {0!s}".format(key))
 
     def _asdict(self):
         """Return the contents of this :class:`.KeyedTuple` as a dictionary.
@@ -132,7 +132,7 @@ class _LW(AbstractKeyedTuple):
 
 class ImmutableContainer(object):
     def _immutable(self, *arg, **kw):
-        raise TypeError("%s object is immutable" % self.__class__.__name__)
+        raise TypeError("{0!s} object is immutable".format(self.__class__.__name__))
 
     __delitem__ = __setitem__ = __setattr__ = _immutable
 
@@ -167,7 +167,7 @@ class immutabledict(ImmutableContainer, dict):
             return d2
 
     def __repr__(self):
-        return "immutabledict(%s)" % dict.__repr__(self)
+        return "immutabledict({0!s})".format(dict.__repr__(self))
 
 
 class Properties(object):
@@ -399,7 +399,7 @@ class OrderedSet(set):
         return self.union(other)
 
     def __repr__(self):
-        return '%s(%r)' % (self.__class__.__name__, self._list)
+        return '{0!s}({1!r})'.format(self.__class__.__name__, self._list)
 
     __str__ = __repr__
 
@@ -667,7 +667,7 @@ class IdentitySet(object):
         raise TypeError('set objects are unhashable')
 
     def __repr__(self):
-        return '%s(%r)' % (type(self).__name__, list(self._members.values()))
+        return '{0!s}({1!r})'.format(type(self).__name__, list(self._members.values()))
 
 
 class WeakSequence(object):
@@ -693,7 +693,7 @@ class WeakSequence(object):
         try:
             obj = self._storage[index]
         except KeyError:
-            raise IndexError("Index %s out of range" % index)
+            raise IndexError("Index {0!s} out of range".format(index))
         else:
             return obj()
 

--- a/lib/sqlalchemy/util/deprecations.py
+++ b/lib/sqlalchemy/util/deprecations.py
@@ -37,8 +37,7 @@ def deprecated(version, message=None, add_deprecation_to_docstring=True):
     """
 
     if add_deprecation_to_docstring:
-        header = ".. deprecated:: %s %s" % \
-            (version, (message or ''))
+        header = ".. deprecated:: {0!s} {1!s}".format(version, (message or ''))
     else:
         header = None
 
@@ -71,8 +70,7 @@ def pending_deprecation(version, message=None,
     """
 
     if add_deprecation_to_docstring:
-        header = ".. deprecated:: %s (pending) %s" % \
-            (version, (message or ''))
+        header = ".. deprecated:: {0!s} (pending) {1!s}".format(version, (message or ''))
     else:
         header = None
 

--- a/lib/sqlalchemy/util/langhelpers.py
+++ b/lib/sqlalchemy/util/langhelpers.py
@@ -96,7 +96,7 @@ def _unique_symbols(used, *bases):
                 yield sym
                 break
         else:
-            raise NameError("exhausted namespace for symbol base %s" % base)
+            raise NameError("exhausted namespace for symbol base {0!s}".format(base))
 
 
 def map_bits(fn, n):
@@ -122,9 +122,9 @@ def decorator(target):
         metadata.update(format_argspec_plus(spec, grouped=False))
         metadata['name'] = fn.__name__
         code = """\
-def %(name)s(%(args)s):
-    return %(target)s(%(fn)s, %(apply_kw)s)
-""" % metadata
+def {name!s}({args!s}):
+    return {target!s}({fn!s}, {apply_kw!s})
+""".format(**metadata)
         decorated = _exec_code_in_env(code,
                                       {targ_name: target, fn_name: fn},
                                       fn.__name__)
@@ -165,9 +165,9 @@ def public_factory(target, location):
     metadata = format_argspec_plus(spec, grouped=False)
     metadata['name'] = location_name
     code = """\
-def %(name)s(%(args)s):
-    return cls(%(apply_kw)s)
-""" % metadata
+def {name!s}({args!s}):
+    return cls({apply_kw!s})
+""".format(**metadata)
     env = {'cls': callable_, 'symbol': symbol}
     exec(code, env)
     decorated = env[location_name]
@@ -208,8 +208,7 @@ class PluginLoader(object):
                 return impl.load()
 
         raise exc.NoSuchModuleError(
-            "Can't load plugin: %s:%s" %
-            (self.group, name))
+            "Can't load plugin: {0!s}:{1!s}".format(self.group, name))
 
     def register(self, name, modulepath, objname):
         def load():
@@ -296,7 +295,7 @@ def get_callable_argspec(fn, no_self=False, _is_init=False):
 
     """
     if inspect.isbuiltin(fn):
-        raise TypeError("Can't inspect builtin: %s" % fn)
+        raise TypeError("Can't inspect builtin: {0!s}".format(fn))
     elif inspect.isfunction(fn):
         if _is_init and no_self:
             spec = compat.inspect_getargspec(fn)
@@ -320,9 +319,9 @@ def get_callable_argspec(fn, no_self=False, _is_init=False):
         if inspect.ismethod(fn.__call__):
             return get_callable_argspec(fn.__call__, no_self=no_self)
         else:
-            raise TypeError("Can't inspect callable: %s" % fn)
+            raise TypeError("Can't inspect callable: {0!s}".format(fn))
     else:
-        raise TypeError("Can't inspect callable: %s" % fn)
+        raise TypeError("Can't inspect callable: {0!s}".format(fn))
 
 
 def format_argspec_plus(fn, grouped=True):
@@ -366,7 +365,7 @@ def format_argspec_plus(fn, grouped=True):
     if spec[0]:
         self_arg = spec[0][0]
     elif spec[1]:
-        self_arg = '%s[0]' % spec[1]
+        self_arg = '{0!s}[0]'.format(spec[1])
     else:
         self_arg = None
 
@@ -507,7 +506,7 @@ def generic_repr(obj, additional_kw=(), to_inspect=None, omit_kwarg=()):
         try:
             val = getattr(obj, arg, missing)
             if val is not missing and val != defval:
-                output.append('%s=%r' % (arg, val))
+                output.append('{0!s}={1!r}'.format(arg, val))
         except Exception:
             pass
 
@@ -516,11 +515,11 @@ def generic_repr(obj, additional_kw=(), to_inspect=None, omit_kwarg=()):
             try:
                 val = getattr(obj, arg, missing)
                 if val is not missing and val != defval:
-                    output.append('%s=%r' % (arg, val))
+                    output.append('{0!s}={1!r}'.format(arg, val))
             except Exception:
                 pass
 
-    return "%s(%s)" % (obj.__class__.__name__, ", ".join(output))
+    return "{0!s}({1!s})".format(obj.__class__.__name__, ", ".join(output))
 
 
 class portable_instancemethod(object):
@@ -715,7 +714,7 @@ def as_interface(obj, cls=None, methods=None, required=None):
     # No dict duck typing here.
     if not isinstance(obj, dict):
         qualifier = complies is operator.gt and 'any of' or 'all of'
-        raise TypeError("%r does not implement %s: %s" % (
+        raise TypeError("{0!r} does not implement {1!s}: {2!s}".format(
             obj, qualifier, ', '.join(interface)))
 
     class AnonymousInterface(object):
@@ -727,17 +726,17 @@ def as_interface(obj, cls=None, methods=None, required=None):
 
     for method, impl in dictlike_iteritems(obj):
         if method not in interface:
-            raise TypeError("%r: unknown in this interface" % method)
+            raise TypeError("{0!r}: unknown in this interface".format(method))
         if not compat.callable(impl):
-            raise TypeError("%r=%r is not callable" % (method, impl))
+            raise TypeError("{0!r}={1!r} is not callable".format(method, impl))
         setattr(AnonymousInterface, method, staticmethod(impl))
         found.add(method)
 
     if complies(found, required):
         return AnonymousInterface
 
-    raise TypeError("dictionary does not contain required keys %s" %
-                    ', '.join(required - found))
+    raise TypeError("dictionary does not contain required keys {0!s}".format(
+                    ', '.join(required - found)))
 
 
 class memoized_property(object):
@@ -820,12 +819,12 @@ class MemoizedSlots(object):
     def __getattr__(self, key):
         if key.startswith('_memoized'):
             raise AttributeError(key)
-        elif hasattr(self, '_memoized_attr_%s' % key):
-            value = getattr(self, '_memoized_attr_%s' % key)()
+        elif hasattr(self, '_memoized_attr_{0!s}'.format(key)):
+            value = getattr(self, '_memoized_attr_{0!s}'.format(key))()
             setattr(self, key, value)
             return value
-        elif hasattr(self, '_memoized_method_%s' % key):
-            fn = getattr(self, '_memoized_method_%s' % key)
+        elif hasattr(self, '_memoized_method_{0!s}'.format(key)):
+            fn = getattr(self, '_memoized_method_{0!s}'.format(key))
 
             def oneshot(*args, **kw):
                 result = fn(*args, **kw)
@@ -890,7 +889,7 @@ class dependencies(object):
         hasself = spec_zero[0] in ('self', 'cls')
 
         for i in range(len(import_deps)):
-            spec[0][i + (1 if hasself else 0)] = "import_deps[%r]" % i
+            spec[0][i + (1 if hasself else 0)] = "import_deps[{0!r}]".format(i)
 
         inner_spec = format_argspec_plus(spec, grouped=False)
 
@@ -900,10 +899,10 @@ class dependencies(object):
 
         outer_spec = format_argspec_plus(spec, grouped=False)
 
-        code = 'lambda %(args)s: fn(%(apply_kw)s)' % {
+        code = 'lambda {args!s}: fn({apply_kw!s})'.format(**{
             "args": outer_spec['args'],
             "apply_kw": inner_spec['apply_kw']
-        }
+        })
 
         decorated = eval(code, locals())
         decorated.__defaults__ = getattr(fn, 'im_func', fn).__defaults__
@@ -958,14 +957,12 @@ class dependencies(object):
 
         def __getattr__(self, key):
             if key == 'module':
-                raise ImportError("Could not resolve module %s"
-                                  % self._full_path)
+                raise ImportError("Could not resolve module {0!s}".format(self._full_path))
             try:
                 attr = getattr(self.module, key)
             except AttributeError:
                 raise AttributeError(
-                    "Module %s has no attribute '%s'" %
-                    (self._full_path, key)
+                    "Module {0!s} has no attribute '{1!s}'".format(self._full_path, key)
                 )
             self.__dict__[key] = attr
             return attr
@@ -980,7 +977,7 @@ def asbool(obj):
         elif obj in ['false', 'no', 'off', 'n', 'f', '0']:
             return False
         else:
-            raise ValueError("String is not true/false: %r" % obj)
+            raise ValueError("String is not true/false: {0!r}".format(obj))
     return bool(obj)
 
 
@@ -1087,12 +1084,10 @@ def assert_arg_type(arg, argtype, name):
     else:
         if isinstance(argtype, tuple):
             raise exc.ArgumentError(
-                "Argument '%s' is expected to be one of type %s, got '%s'" %
-                (name, ' or '.join("'%s'" % a for a in argtype), type(arg)))
+                "Argument '{0!s}' is expected to be one of type {1!s}, got '{2!s}'".format(name, ' or '.join("'{0!s}'".format(a) for a in argtype), type(arg)))
         else:
             raise exc.ArgumentError(
-                "Argument '%s' is expected to be of type '%s', got '%s'" %
-                (name, argtype, type(arg)))
+                "Argument '{0!s}' is expected to be of type '{1!s}', got '{2!s}'".format(name, argtype, type(arg)))
 
 
 def dictlike_iteritems(dictlike):
@@ -1110,7 +1105,7 @@ def dictlike_iteritems(dictlike):
     getter = getattr(dictlike, '__getitem__', getattr(dictlike, 'get', None))
     if getter is None:
         raise TypeError(
-            "Object '%r' is not dict-like" % dictlike)
+            "Object '{0!r}' is not dict-like".format(dictlike))
 
     if hasattr(dictlike, 'iterkeys'):
         def iterator():
@@ -1121,7 +1116,7 @@ def dictlike_iteritems(dictlike):
         return iter((key, getter(key)) for key in dictlike.keys())
     else:
         raise TypeError(
-            "Object '%r' is not dict-like" % dictlike)
+            "Object '{0!r}' is not dict-like".format(dictlike))
 
 
 class classproperty(property):
@@ -1188,7 +1183,7 @@ class _symbol(int):
         return repr(self)
 
     def __repr__(self):
-        return "symbol(%r)" % self.name
+        return "symbol({0!r})".format(self.name)
 
 _symbol.__name__ = 'symbol'
 
@@ -1252,13 +1247,13 @@ def warn_exception(func, *args, **kwargs):
     try:
         return func(*args, **kwargs)
     except Exception:
-        warn("%s('%s') ignored" % sys.exc_info()[0:2])
+        warn("{0!s}('{1!s}') ignored".format(*sys.exc_info()[0:2]))
 
 
 def ellipses_string(value, len_=25):
     try:
         if len(value) > len_:
-            return "%s..." % value[0:len_]
+            return "{0!s}...".format(value[0:len_])
         else:
             return value
     except TypeError:
@@ -1277,9 +1272,9 @@ class _hash_limit_string(compat.text_type):
     """
     def __new__(cls, value, num, args):
         interpolated = (value % args) + \
-            (" (this warning may be suppressed after %d occurrences)" % num)
+            (" (this warning may be suppressed after {0:d} occurrences)".format(num))
         self = super(_hash_limit_string, cls).__new__(cls, interpolated)
-        self._hash = hash("%s_%d" % (value, hash(interpolated) % num))
+        self._hash = hash("{0!s}_{1:d}".format(value, hash(interpolated) % num))
         return self
 
     def __hash__(self):

--- a/test/aaa_profiling/test_memusage.py
+++ b/test/aaa_profiling/test_memusage.py
@@ -302,7 +302,7 @@ class MemUsageTest(EnsureZeroed):
         wide_table = Table('t', metadata,
                            Column('id', Integer, primary_key=True,
                                   test_needs_autoincrement=True),
-                           *[Column('col%d' % i, Integer) for i in range(10)]
+                           *[Column('col{0:d}'.format(i), Integer) for i in range(10)]
                            )
 
         class Wide(object):
@@ -329,7 +329,7 @@ class MemUsageTest(EnsureZeroed):
                 # trying to count in binary here,
                 # works enough to trip the test case
                 if pow(2, dec) < x:
-                    setattr(w1, 'col%d' % dec, counter[0])
+                    setattr(w1, 'col{0:d}'.format(dec), counter[0])
                     x -= pow(2, dec)
                 dec -= 1
             session.flush()
@@ -369,7 +369,7 @@ class MemUsageTest(EnsureZeroed):
             # this warning shouldn't clog up memory.
 
             self.engine.execute(table1.select().where(table1.c.col2
-                                                     == 'foo%d' % i[0]))
+                                                     == 'foo{0:d}'.format(i[0])))
             i[0] += 1
         try:
             go()

--- a/test/aaa_profiling/test_orm.py
+++ b/test/aaa_profiling/test_orm.py
@@ -159,13 +159,13 @@ class LoadManyToOneFromIdentityTest(fixtures.MappedTest):
         parent, child = cls.tables.parent, cls.tables.child
 
         child.insert().execute([
-            {'id': i, 'data': 'c%d' % i}
+            {'id': i, 'data': 'c{0:d}'.format(i)}
             for i in range(1, 251)
         ])
         parent.insert().execute([
             {
                 'id': i,
-                'data': 'p%dc%d' % (i, (i % 250) + 1),
+                'data': 'p{0:d}c{1:d}'.format(i, (i % 250) + 1),
                 'child_id': (i % 250) + 1
             }
             for i in range(1, 1000)
@@ -309,7 +309,7 @@ class DeferOptionsTest(fixtures.MappedTest):
         s = Session()
         s.add_all([
             A(id=i,
-                **dict((letter, "%s%d" % (letter, i)) for letter in
+                **dict((letter, "{0!s}{1:d}".format(letter, i)) for letter in
                        ['x', 'y', 'z', 'p', 'q', 'r'])
               ) for i in range(1, 1001)
         ])

--- a/test/aaa_profiling/test_resultset.py
+++ b/test/aaa_profiling/test_resultset.py
@@ -20,19 +20,19 @@ class ResultSetTest(fixtures.TestBase, AssertsExecutionResults):
     def setup_class(cls):
         global t, t2, metadata
         metadata = MetaData(testing.db)
-        t = Table('table', metadata, *[Column('field%d' % fnum, String(50))
+        t = Table('table', metadata, *[Column('field{0:d}'.format(fnum), String(50))
                                        for fnum in range(NUM_FIELDS)])
         t2 = Table(
             'table2', metadata, *
-            [Column('field%d' % fnum, Unicode(50))
+            [Column('field{0:d}'.format(fnum), Unicode(50))
              for fnum in range(NUM_FIELDS)])
 
     def setup(self):
         metadata.create_all()
-        t.insert().execute([dict(('field%d' % fnum, u('value%d' % fnum))
+        t.insert().execute([dict(('field{0:d}'.format(fnum), u('value{0:d}'.format(fnum)))
                                  for fnum in range(NUM_FIELDS)) for r_num in
                             range(NUM_RECORDS)])
-        t2.insert().execute([dict(('field%d' % fnum, u('value%d' % fnum))
+        t2.insert().execute([dict(('field{0:d}'.format(fnum), u('value{0:d}'.format(fnum)))
                                   for fnum in range(NUM_FIELDS)) for r_num in
                              range(NUM_RECORDS)])
 

--- a/test/aaa_profiling/test_zoomark.py
+++ b/test/aaa_profiling/test_zoomark.py
@@ -144,7 +144,7 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
         Animal = self.metadata.tables['Animal']
         i = Animal.insert(inline=True)
         for x in range(ITERATIONS):
-            i.execute(Species='Tick', Name='Tick %d' % x, Legs=8)
+            i.execute(Species='Tick', Name='Tick {0:d}'.format(x), Legs=8)
 
     def _baseline_3_properties(self):
         Zoo = self.metadata.tables['Zoo']

--- a/test/aaa_profiling/test_zoomark_orm.py
+++ b/test/aaa_profiling/test_zoomark_orm.py
@@ -150,7 +150,7 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
 
     def _baseline_2_insert(self):
         for x in range(ITERATIONS):
-            self.session.add(Animal(Species='Tick', Name='Tick %d' % x,
+            self.session.add(Animal(Species='Tick', Name='Tick {0:d}'.format(x),
                                Legs=8))
         self.session.flush()
 

--- a/test/base/test_dependency.py
+++ b/test/base/test_dependency.py
@@ -300,7 +300,7 @@ class DependencySortTest(fixtures.TestBase):
               ('node4', 'node17'), ('node2', 'node20'), ('node19', 'node10'),
               ('node8', 'node4'), ('node11', 'node3'), ('node6', 'node1')
         ]
-        allnodes = ['node%d' % i for i in range(1, 21)]
+        allnodes = ['node{0:d}'.format(i) for i in range(1, 21)]
         eq_(
             topological.find_cycles(tuples, allnodes),
             set(['node11', 'node10', 'node13', 'node15', 'node14', 'node17',

--- a/test/base/test_events.py
+++ b/test/base/test_events.py
@@ -211,7 +211,7 @@ class NamedCallTest(fixtures.TestBase):
                 fn = event_key._listen_fn
 
                 def adapt(*args):
-                    fn(*["adapted %s" % arg for arg in args])
+                    fn(*["adapted {0!s}".format(arg) for arg in args])
                 event_key = event_key.with_wrapper(adapt)
 
                 event_key.base_listen()

--- a/test/base/test_except.py
+++ b/test/base/test_except.py
@@ -22,7 +22,7 @@ class OperationalError(DatabaseError):
 class ProgrammingError(DatabaseError):
 
     def __str__(self):
-        return '<%s>' % self.bogus
+        return '<{0!s}>'.format(self.bogus)
 
 
 class OutOfSpec(DatabaseError):

--- a/test/base/test_tutorials.py
+++ b/test/base/test_tutorials.py
@@ -73,7 +73,7 @@ class DocTest(fixtures.TestBase):
         sqla_base = os.path.normpath(os.path.join(here, "..", ".."))
         path = os.path.join(sqla_base, "doc/build", fname)
         if not os.path.exists(path):
-            config.skip_test("Can't find documentation file %r" % path)
+            config.skip_test("Can't find documentation file {0!r}".format(path))
         with open(path) as file_:
             content = file_.read()
             content = re.sub(r'{(?:stop|sql|opensql)}', '', content)

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -649,7 +649,7 @@ class LRUTest(fixtures.TestBase):
                 self.id = id
 
             def __str__(self):
-                return "item id %d" % self.id
+                return "item id {0:d}".format(self.id)
 
         l = util.LRUCache(10, threshold=.2)
 

--- a/test/dialect/mssql/test_compiler.py
+++ b/test/dialect/mssql/test_compiler.py
@@ -384,7 +384,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         for field in 'day', 'month', 'year':
             self.assert_compile(
                 select([extract(field, t.c.col1)]),
-                'SELECT DATEPART(%s, t.col1) AS anon_1 FROM t' % field)
+                'SELECT DATEPART({0!s}, t.col1) AS anon_1 FROM t'.format(field))
 
     def test_update_returning(self):
         table1 = table(

--- a/test/dialect/mssql/test_query.py
+++ b/test/dialect/mssql/test_query.py
@@ -207,7 +207,7 @@ class QueryUnicodeTest(fixtures.TestBase):
         try:
             r = t1.select().execute().first()
             assert isinstance(r[1], util.text_type), \
-                '%s is %s instead of unicode, working on %s' % (
+                '{0!s} is {1!s} instead of unicode, working on {2!s}'.format(
                 r[1],
                 type(r[1]), meta.bind)
         finally:

--- a/test/dialect/mssql/test_reflection.py
+++ b/test/dialect/mssql/test_reflection.py
@@ -101,7 +101,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
 
         inspector = inspect(testing.db)
         bar_via_db = inspector.get_foreign_keys(
-                            "bar", schema="%s.%s" % (dbname, owner))
+                            "bar", schema="{0!s}.{1!s}".format(dbname, owner))
         eq_(
             bar_via_db,
             [{
@@ -243,15 +243,15 @@ class ReflectHugeViewTest(fixtures.TestBase):
         self.metadata = MetaData(testing.db)
         t = Table('base_table', self.metadata,
                 *[
-                    Column("long_named_column_number_%d" % i, Integer)
+                    Column("long_named_column_number_{0:d}".format(i), Integer)
                     for i in range(self.col_num)
                 ]
         )
         self.view_str = view_str = \
-            "CREATE VIEW huge_named_view AS SELECT %s FROM base_table" % (
-            ",".join("long_named_column_number_%d" % i
+            "CREATE VIEW huge_named_view AS SELECT {0!s} FROM base_table".format((
+            ",".join("long_named_column_number_{0:d}".format(i)
                         for i in range(self.col_num))
-            )
+            ))
         assert len(view_str) > 4000
 
         event.listen(t, 'after_create', DDL(view_str) )

--- a/test/dialect/mssql/test_types.py
+++ b/test/dialect/mssql/test_types.py
@@ -94,7 +94,7 @@ class TypeDDLTest(fixtures.TestBase):
         for index, spec in enumerate(columns):
             type_, args, kw, res = spec
             table_args.append(
-                Column('c%s' % index, type_(*args, **kw), nullable=None))
+                Column('c{0!s}'.format(index), type_(*args, **kw), nullable=None))
 
         boolean_table = Table(*table_args)
         dialect = mssql.dialect()
@@ -104,7 +104,7 @@ class TypeDDLTest(fixtures.TestBase):
             index = int(col.name[1:])
             testing.eq_(
                 gen.get_column_specification(col),
-                "%s %s" % (col.name, columns[index][3]))
+                "{0!s} {1!s}".format(col.name, columns[index][3]))
             self.assert_(repr(col))
 
     def test_numeric(self):
@@ -143,7 +143,7 @@ class TypeDDLTest(fixtures.TestBase):
         for index, spec in enumerate(columns):
             type_, args, kw, res = spec
             table_args.append(
-                Column('c%s' % index, type_(*args, **kw), nullable=None))
+                Column('c{0!s}'.format(index), type_(*args, **kw), nullable=None))
 
         numeric_table = Table(*table_args)
         dialect = mssql.dialect()
@@ -153,7 +153,7 @@ class TypeDDLTest(fixtures.TestBase):
             index = int(col.name[1:])
             testing.eq_(
                 gen.get_column_specification(col),
-                "%s %s" % (col.name, columns[index][3]))
+                "{0!s} {1!s}".format(col.name, columns[index][3]))
             self.assert_(repr(col))
 
     def test_char(self):
@@ -204,7 +204,7 @@ class TypeDDLTest(fixtures.TestBase):
         for index, spec in enumerate(columns):
             type_, args, kw, res = spec
             table_args.append(
-                Column('c%s' % index, type_(*args, **kw), nullable=None))
+                Column('c{0!s}'.format(index), type_(*args, **kw), nullable=None))
 
         charset_table = Table(*table_args)
         dialect = mssql.dialect()
@@ -214,7 +214,7 @@ class TypeDDLTest(fixtures.TestBase):
             index = int(col.name[1:])
             testing.eq_(
                 gen.get_column_specification(col),
-                "%s %s" % (col.name, columns[index][3]))
+                "{0!s} {1!s}".format(col.name, columns[index][3]))
             self.assert_(repr(col))
 
     def test_dates(self):
@@ -277,7 +277,7 @@ class TypeDDLTest(fixtures.TestBase):
         for index, spec in enumerate(columns):
             type_, args, kw, res, server_version = spec
             table_args.append(
-                Column('c%s' % index, type_(*args, **kw), nullable=None))
+                Column('c{0!s}'.format(index), type_(*args, **kw), nullable=None))
 
         date_table = Table(*table_args)
         dialect = mssql.dialect()
@@ -294,11 +294,11 @@ class TypeDDLTest(fixtures.TestBase):
             if not server_version:
                 testing.eq_(
                     gen.get_column_specification(col),
-                    "%s %s" % (col.name, columns[index][3]))
+                    "{0!s} {1!s}".format(col.name, columns[index][3]))
             else:
                 testing.eq_(
                     gen2005.get_column_specification(col),
-                    "%s %s" % (col.name, columns[index][3]))
+                    "{0!s} {1!s}".format(col.name, columns[index][3]))
 
             self.assert_(repr(col))
 
@@ -352,7 +352,7 @@ class TypeDDLTest(fixtures.TestBase):
             Column('id', Integer, primary_key=True),
             Column('t', spec, nullable=None))
         gen = dialect.ddl_compiler(dialect, schema.CreateTable(t))
-        testing.eq_(gen.get_column_specification(t.c.t), "t %s" % expected)
+        testing.eq_(gen.get_column_specification(t.c.t), "t {0!s}".format(expected))
         self.assert_(repr(t.c.t))
 
     def test_money(self):
@@ -364,7 +364,7 @@ class TypeDDLTest(fixtures.TestBase):
         table_args = ['test_mssql_money', metadata]
         for index, spec in enumerate(columns):
             type_, args, kw, res = spec
-            table_args.append(Column('c%s' % index, type_(*args, **kw),
+            table_args.append(Column('c{0!s}'.format(index), type_(*args, **kw),
                               nullable=None))
         money_table = Table(*table_args)
         dialect = mssql.dialect()
@@ -372,8 +372,7 @@ class TypeDDLTest(fixtures.TestBase):
                                    schema.CreateTable(money_table))
         for col in money_table.c:
             index = int(col.name[1:])
-            testing.eq_(gen.get_column_specification(col), '%s %s'
-                        % (col.name, columns[index][3]))
+            testing.eq_(gen.get_column_specification(col), '{0!s} {1!s}'.format(col.name, columns[index][3]))
             self.assert_(repr(col))
 
     def test_binary(self):
@@ -415,7 +414,7 @@ class TypeDDLTest(fixtures.TestBase):
         table_args = ['test_mssql_binary', metadata]
         for index, spec in enumerate(columns):
             type_, args, kw, res = spec
-            table_args.append(Column('c%s' % index, type_(*args, **kw),
+            table_args.append(Column('c{0!s}'.format(index), type_(*args, **kw),
                               nullable=None))
         binary_table = Table(*table_args)
         dialect = mssql.dialect()
@@ -423,8 +422,7 @@ class TypeDDLTest(fixtures.TestBase):
                                    schema.CreateTable(binary_table))
         for col in binary_table.c:
             index = int(col.name[1:])
-            testing.eq_(gen.get_column_specification(col), '%s %s'
-                        % (col.name, columns[index][3]))
+            testing.eq_(gen.get_column_specification(col), '{0!s} {1!s}'.format(col.name, columns[index][3]))
             self.assert_(repr(col))
 
 metadata = None
@@ -508,7 +506,7 @@ class TypeRoundTripTest(
             numeric_table.insert().execute(numericcol=value)
 
         for value in select([numeric_table.c.numericcol]).execute():
-            assert value[0] in test_items, "%r not in test_items" % value[0]
+            assert value[0] in test_items, "{0!r} not in test_items".format(value[0])
 
     def test_float(self):
         float_table = Table(
@@ -607,7 +605,7 @@ class TypeRoundTripTest(
             type_, args, kw, res, requires = spec[0:5]
             if requires and \
                     testing._is_excluded('mssql', *requires) or not requires:
-                c = Column('c%s' % index, type_(*args, **kw), nullable=None)
+                c = Column('c{0!s}'.format(index), type_(*args, **kw), nullable=None)
                 testing.db.dialect.type_descriptor(c.type)
                 table_args.append(c)
         dates_table = Table(*table_args)
@@ -616,8 +614,7 @@ class TypeRoundTripTest(
             schema.CreateTable(dates_table))
         for col in dates_table.c:
             index = int(col.name[1:])
-            testing.eq_(gen.get_column_specification(col), '%s %s'
-                        % (col.name, columns[index][3]))
+            testing.eq_(gen.get_column_specification(col), '{0!s} {1!s}'.format(col.name, columns[index][3]))
             self.assert_(repr(col))
         dates_table.create(checkfirst=True)
         reflected_dates = Table('test_mssql_dates',
@@ -696,7 +693,7 @@ class TypeRoundTripTest(
         table_args = ['test_mssql_binary', metadata]
         for index, spec in enumerate(columns):
             type_, args, kw, res = spec
-            table_args.append(Column('c%s' % index, type_(*args, **kw),
+            table_args.append(Column('c{0!s}'.format(index), type_(*args, **kw),
                               nullable=None))
         binary_table = Table(*table_args)
         metadata.create_all()
@@ -705,15 +702,14 @@ class TypeRoundTripTest(
         for col, spec in zip(reflected_binary.c, columns):
             eq_(
                 str(col.type), spec[3],
-                "column %s %s != %s" % (col.key, str(col.type), spec[3])
+                "column {0!s} {1!s} != {2!s}".format(col.key, str(col.type), spec[3])
             )
             c1 = testing.db.dialect.type_descriptor(col.type).__class__
             c2 = \
                 testing.db.dialect.type_descriptor(
                     binary_table.c[col.name].type).__class__
             assert issubclass(c1, c2), \
-                'column %s: %r is not a subclass of %r' \
-                % (col.key, c1, c2)
+                'column {0!s}: {1!r} is not a subclass of {2!r}'.format(col.key, c1, c2)
             if binary_table.c[col.name].type.length:
                 testing.eq_(col.type.length,
                             binary_table.c[col.name].type.length)

--- a/test/dialect/mysql/test_compiler.py
+++ b/test/dialect/mysql/test_compiler.py
@@ -518,7 +518,7 @@ class SQLTest(fixtures.TestBase, AssertsCompiledSQL):
         for field in 'year', 'month', 'day':
             self.assert_compile(
                 select([extract(field, t.c.col1)]),
-                "SELECT EXTRACT(%s FROM t.col1) AS anon_1 FROM t" % field)
+                "SELECT EXTRACT({0!s} FROM t.col1) AS anon_1 FROM t".format(field))
 
         # millsecondS to millisecond
         self.assert_compile(

--- a/test/dialect/mysql/test_dialect.py
+++ b/test/dialect/mysql/test_dialect.py
@@ -128,7 +128,7 @@ class SQLModeDetectionTest(fixtures.TestBase):
     def _options(self, modes):
         def connect(con, record):
             cursor = con.cursor()
-            cursor.execute("set sql_mode='%s'" % (",".join(modes)))
+            cursor.execute("set sql_mode='{0!s}'".format((",".join(modes))))
         e = engines.testing_engine(options={
             'pool_events':[
                 (connect, 'first_connect'),

--- a/test/dialect/mysql/test_reflection.py
+++ b/test/dialect/mysql/test_reflection.py
@@ -20,7 +20,7 @@ class TypeReflectionTest(fixtures.TestBase):
 
     @testing.provide_metadata
     def _run_test(self, specs, attributes):
-        columns = [Column('c%i' % (i + 1), t[0]) for i, t in enumerate(specs)]
+        columns = [Column('c{0:d}'.format((i + 1)), t[0]) for i, t in enumerate(specs)]
 
         # Early 5.0 releases seem to report more "general" for columns
         # in a view, e.g. char -> varchar, tinyblob -> mediumblob
@@ -61,7 +61,7 @@ class TypeReflectionTest(fixtures.TestBase):
                         getattr(expected_spec, attr),
                         "Column %s: Attribute %s value of %s does not "
                         "match %s for type %s" % (
-                            "c%i" % (i + 1),
+                            "c{0:d}".format((i + 1)),
                             attr,
                             getattr(reflected_type, attr),
                             getattr(expected_spec, attr),
@@ -415,7 +415,7 @@ class ReflectionTest(fixtures.TestBase, AssertsExecutionResults):
         def cleanup(*arg, **kw):
             with testing.db.connect() as conn:
                 for v in ['v1', 'v2', 'v3', 'v4']:
-                    conn.execute("DROP VIEW %s" % v)
+                    conn.execute("DROP VIEW {0!s}".format(v))
 
         insp = inspect(testing.db)
         for v in ['v1', 'v2', 'v3', 'v4']:
@@ -461,19 +461,19 @@ class ReflectionTest(fixtures.TestBase, AssertsExecutionResults):
             ["t TIMESTAMP"],
             ["u TIMESTAMP DEFAULT CURRENT_TIMESTAMP"]
         ]):
-            Table("nn_t%d" % idx, meta)  # to allow DROP
+            Table("nn_t{0:d}".format(idx), meta)  # to allow DROP
 
             testing.db.execute("""
-                CREATE TABLE nn_t%d (
-                    %s
+                CREATE TABLE nn_t{0:d} (
+                    {1!s}
                 )
-            """ % (idx, ", \n".join(cols)))
+            """.format(idx, ", \n".join(cols)))
 
             reflected.extend(
                 {
                     "name": d['name'], "nullable": d['nullable'],
                     "default": d['default']}
-                for d in inspect(testing.db).get_columns("nn_t%d" % idx)
+                for d in inspect(testing.db).get_columns("nn_t{0:d}".format(idx))
             )
 
         eq_(

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -152,7 +152,7 @@ class TypesTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
             )
             # test that repr() copies out all arguments
             self.assert_compile(
-                eval("mysql.%r" % type_inst),
+                eval("mysql.{0!r}".format(type_inst)),
                 res
             )
 
@@ -256,9 +256,9 @@ class TypesTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
             )
             # test that repr() copies out all arguments
             self.assert_compile(
-                eval("mysql.%r" % type_inst)
+                eval("mysql.{0!r}".format(type_inst))
                     if type_ is not String
-                    else eval("%r" % type_inst),
+                    else eval("{0!r}".format(type_inst)),
                 res
             )
 
@@ -322,9 +322,9 @@ class TypesTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
                 try:
                     self.assert_(list(row) == expected)
                 except:
-                    print("Storing %s" % store)
-                    print("Expected %s" % expected)
-                    print("Found %s" % list(row))
+                    print("Storing {0!s}".format(store))
+                    print("Expected {0!s}".format(expected))
+                    print("Found {0!s}".format(list(row)))
                     raise
                 table.delete().execute().close()
 
@@ -481,7 +481,7 @@ class TypesTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
             Table('t', MetaData(), c)
             self.assert_compile(
                 schema.CreateColumn(c),
-                "t %s" % expected
+                "t {0!s}".format(expected)
 
             )
 

--- a/test/dialect/postgresql/test_dialect.py
+++ b/test/dialect/postgresql/test_dialect.py
@@ -74,7 +74,7 @@ class MiscTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
         # under pypy the name here is psycopg2cffi
         psycopg2 = testing.db.dialect.dbapi
         TransactionRollbackError = __import__(
-            "%s.extensions" % psycopg2.__name__
+            "{0!s}.extensions".format(psycopg2.__name__)
         ).extensions.TransactionRollbackError
 
         exception = exc.DBAPIError.instance(
@@ -293,5 +293,5 @@ class MiscTest(fixtures.TestBase, AssertsExecutionResults, AssertsCompiledSQL):
             ddl_compiler = dialect.ddl_compiler(dialect, schema.CreateTable(t))
             eq_(
                 ddl_compiler.get_column_specification(t.c.c),
-                "c %s NOT NULL" % expected
+                "c {0!s} NOT NULL".format(expected)
             )

--- a/test/dialect/postgresql/test_query.py
+++ b/test/dialect/postgresql/test_query.py
@@ -845,7 +845,7 @@ class TupleTest(fixtures.TestBase):
                         ).
                         in_([
                             tuple_(*[
-                                literal_column("'%s'" % letter)
+                                literal_column("'{0!s}'".format(letter))
                                 for letter in elem
                             ]) for elem in test
                         ])

--- a/test/dialect/postgresql/test_reflection.py
+++ b/test/dialect/postgresql/test_reflection.py
@@ -317,8 +317,8 @@ class ReflectionTest(fixtures.TestBase):
         m = MetaData()
         t = Table('t', m, autoload=True, autoload_with=testing.db)
         eq_(
-            t.c.x.server_default.arg.text, "'%s'::character varying" % (
-                "abcd" * 40)
+            t.c.x.server_default.arg.text, "'{0!s}'::character varying".format((
+                "abcd" * 40))
         )
 
     @testing.fails_if("postgresql < 8.1", "schema name leaks in, not sure")

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -2396,7 +2396,7 @@ class DateTimeTZRangeTests(_RangeTypeMixin, fixtures.TablesTest):
 
     @property
     def _data_str(self):
-        return '[%s,%s)' % self.tstzs()
+        return '[{0!s},{1!s})'.format(*self.tstzs())
 
     def _data_obj(self):
         return self.extras().DateTimeTZRange(*self.tstzs())

--- a/test/dialect/test_firebird.py
+++ b/test/dialect/test_firebird.py
@@ -480,7 +480,7 @@ class ArgumentTest(fixtures.TestBase):
                     _initialize=False
             )
         )
-        engine = engines.testing_engine("firebird+%s://" % type_,
+        engine = engines.testing_engine("firebird+{0!s}://".format(type_),
                                 options=kw)
         return engine
 

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -71,7 +71,7 @@ class TestTypes(fixtures.TestBase, AssertsExecutionResults):
         ]:
             assert_raises_message(
                 ValueError,
-                "Couldn't parse %s string." % disp,
+                "Couldn't parse {0!s} string.".format(disp),
                 lambda: testing.db.execute(
                     text("select 'ASDF' as value", typemap={"value": typ})
                 ).scalar()
@@ -328,7 +328,7 @@ class DefaultsTest(fixtures.TestBase, AssertsCompiledSQL):
 
         specs = [(String(3), '"foo"'), (sqltypes.NUMERIC(10, 2), '100.50'),
                  (Integer, '5'), (Boolean, 'False')]
-        columns = [Column('c%i' % (i + 1), t[0],
+        columns = [Column('c{0:d}'.format((i + 1)), t[0],
                    server_default=text(t[1])) for (i, t) in
                    enumerate(specs)]
         db = testing.db
@@ -1184,7 +1184,7 @@ class ConstraintReflectionTest(fixtures.TestBase):
                 "m", "main.l", "k", "j", "i", "h", "g", "f", "e", "e1",
                     "d", "d1", "d2", "c", "b", "a1", "a2"]:
                 try:
-                    conn.execute("drop table %s" % name)
+                    conn.execute("drop table {0!s}".format(name))
                 except:
                     pass
 
@@ -1652,7 +1652,7 @@ class TypeReflectionTest(fixtures.TestBase):
         conn = testing.db.connect()
         for from_, to_ in self._fixture_as_string(fixture):
             inspector = inspect(conn)
-            conn.execute("CREATE TABLE foo (data %s)" % from_)
+            conn.execute("CREATE TABLE foo (data {0!s})".format(from_))
             try:
                 if warnings:
                     def go():

--- a/test/dialect/test_sybase.py
+++ b/test/dialect/test_sybase.py
@@ -23,7 +23,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         for field, subst in list(mapping.items()):
             self.assert_compile(
                 select([extract(field, t.c.col1)]),
-                'SELECT DATEPART("%s", t.col1) AS anon_1 FROM t' % subst)
+                'SELECT DATEPART("{0!s}", t.col1) AS anon_1 FROM t'.format(subst))
 
     def test_offset_not_supported(self):
         stmt = select([1]).offset(10)

--- a/test/engine/test_execute.py
+++ b/test/engine/test_execute.py
@@ -922,12 +922,12 @@ class SchemaTranslateTest(fixtures.TestBase, testing.AssertsExecutionResults):
                 t1.drop(conn)
 
         asserter.assert_(
-            CompiledSQL("CREATE TABLE %s.t1 (x INTEGER)" % config.test_schema),
-            CompiledSQL("CREATE TABLE %s.t2 (x INTEGER)" % config.test_schema),
+            CompiledSQL("CREATE TABLE {0!s}.t1 (x INTEGER)".format(config.test_schema)),
+            CompiledSQL("CREATE TABLE {0!s}.t2 (x INTEGER)".format(config.test_schema)),
             CompiledSQL("CREATE TABLE t3 (x INTEGER)"),
             CompiledSQL("DROP TABLE t3"),
-            CompiledSQL("DROP TABLE %s.t2" % config.test_schema),
-            CompiledSQL("DROP TABLE %s.t1" % config.test_schema)
+            CompiledSQL("DROP TABLE {0!s}.t2".format(config.test_schema)),
+            CompiledSQL("DROP TABLE {0!s}.t1".format(config.test_schema))
         )
 
     def _fixture(self):
@@ -1003,25 +1003,25 @@ class SchemaTranslateTest(fixtures.TestBase, testing.AssertsExecutionResults):
 
         asserter.assert_(
             CompiledSQL(
-                "INSERT INTO %s.t1 (x) VALUES (:x)" % config.test_schema),
+                "INSERT INTO {0!s}.t1 (x) VALUES (:x)".format(config.test_schema)),
             CompiledSQL(
-                "INSERT INTO %s.t2 (x) VALUES (:x)" % config.test_schema),
+                "INSERT INTO {0!s}.t2 (x) VALUES (:x)".format(config.test_schema)),
             CompiledSQL(
                 "INSERT INTO t3 (x) VALUES (:x)"),
             CompiledSQL(
-                "UPDATE %s.t1 SET x=:x WHERE %s.t1.x = :x_1" % (
+                "UPDATE {0!s}.t1 SET x=:x WHERE {1!s}.t1.x = :x_1".format(
                     config.test_schema, config.test_schema)),
             CompiledSQL(
-                "UPDATE %s.t2 SET x=:x WHERE %s.t2.x = :x_1" % (
+                "UPDATE {0!s}.t2 SET x=:x WHERE {1!s}.t2.x = :x_1".format(
                     config.test_schema, config.test_schema)),
             CompiledSQL("UPDATE t3 SET x=:x WHERE t3.x = :x_1"),
-            CompiledSQL("SELECT %s.t1.x FROM %s.t1" % (
+            CompiledSQL("SELECT {0!s}.t1.x FROM {1!s}.t1".format(
                 config.test_schema, config.test_schema)),
-            CompiledSQL("SELECT %s.t2.x FROM %s.t2" % (
+            CompiledSQL("SELECT {0!s}.t2.x FROM {1!s}.t2".format(
                 config.test_schema, config.test_schema)),
             CompiledSQL("SELECT t3.x FROM t3"),
-            CompiledSQL("DELETE FROM %s.t1" % config.test_schema),
-            CompiledSQL("DELETE FROM %s.t2" % config.test_schema),
+            CompiledSQL("DELETE FROM {0!s}.t1".format(config.test_schema)),
+            CompiledSQL("DELETE FROM {0!s}.t2".format(config.test_schema)),
             CompiledSQL("DELETE FROM t3")
         )
 
@@ -1041,7 +1041,7 @@ class SchemaTranslateTest(fixtures.TestBase, testing.AssertsExecutionResults):
             conn = eng.connect()
             conn.execute(select([t2.c.x]))
         asserter.assert_(
-            CompiledSQL("SELECT %s.t2.x FROM %s.t2" % (
+            CompiledSQL("SELECT {0!s}.t2.x FROM {1!s}.t2".format(
                 config.test_schema, config.test_schema)),
         )
 
@@ -1115,7 +1115,7 @@ class EngineEventsTest(fixtures.TestBase):
         orig = list(received)
         for stmt, params, posn in expected:
             if not received:
-                assert False, "Nothing available for stmt: %s" % stmt
+                assert False, "Nothing available for stmt: {0!s}".format(stmt)
             while received:
                 teststmt, testparams, testmultiparams = \
                     received.pop(0)
@@ -1561,14 +1561,14 @@ class EngineEventsTest(fixtures.TestBase):
                      'rollback_savepoint', 'release_savepoint',
                      'rollback', 'begin_twophase',
                      'prepare_twophase', 'commit_twophase']:
-            event.listen(engine, '%s' % name, tracker1(name))
+            event.listen(engine, '{0!s}'.format(name), tracker1(name))
 
         conn = engine.connect()
         for name in ['begin', 'savepoint',
                      'rollback_savepoint', 'release_savepoint',
                      'rollback', 'begin_twophase',
                      'prepare_twophase', 'commit_twophase']:
-            event.listen(conn, '%s' % name, tracker2(name))
+            event.listen(conn, '{0!s}'.format(name), tracker2(name))
 
         trans = conn.begin()
         trans2 = conn.begin_nested()
@@ -2274,7 +2274,7 @@ class ProxyConnectionTest(fixtures.TestBase):
         def assert_stmts(expected, received):
             for stmt, params, posn in expected:
                 if not received:
-                    assert False, "Nothing available for stmt: %s" % stmt
+                    assert False, "Nothing available for stmt: {0!s}".format(stmt)
                 while received:
                     teststmt, testparams, testmultiparams = \
                         received.pop(0)

--- a/test/engine/test_logging.py
+++ b/test/engine/test_logging.py
@@ -65,7 +65,7 @@ class LogParamsTest(fixtures.TestBase):
 
         eq_(
             self.buf.buffer[1].message,
-            "('%s ... (4702 characters truncated) ... %s',)" % (
+            "('{0!s} ... (4702 characters truncated) ... {1!s}',)".format(
                 largeparam[0:149], largeparam[-149:]
             )
         )
@@ -83,7 +83,7 @@ class LogParamsTest(fixtures.TestBase):
 
         eq_(
             self.buf.buffer[1].message,
-            "('%s', '%s', '%s ... (372 characters truncated) ... %s')" % (
+            "('{0!s}', '{1!s}', '{2!s} ... (372 characters truncated) ... {3!s}')".format(
                 lp1, lp2, lp3[0:149], lp3[-149:]
             )
         )
@@ -146,7 +146,7 @@ class LogParamsTest(fixtures.TestBase):
 
         eq_(
             self.buf.buffer[1].message,
-            "('%s ... (4702 characters truncated) ... %s',)" % (
+            "('{0!s} ... (4702 characters truncated) ... {1!s}',)".format(
                 largeparam[0:149], largeparam[-149:]
             )
         )
@@ -154,14 +154,14 @@ class LogParamsTest(fixtures.TestBase):
         if util.py3k:
             eq_(
                 self.buf.buffer[3].message,
-                "Row ('%s ... (4702 characters truncated) ... %s',)" % (
+                "Row ('{0!s} ... (4702 characters truncated) ... {1!s}',)".format(
                     largeparam[0:149], largeparam[-149:]
                 )
             )
         else:
             eq_(
                 self.buf.buffer[3].message,
-                "Row (u'%s ... (4703 characters truncated) ... %s',)" % (
+                "Row (u'{0!s} ... (4703 characters truncated) ... {1!s}',)".format(
                     largeparam[0:148], largeparam[-149:]
                 )
             )
@@ -169,14 +169,14 @@ class LogParamsTest(fixtures.TestBase):
         if util.py3k:
             eq_(
                 repr(row),
-                "('%s ... (4702 characters truncated) ... %s',)" % (
+                "('{0!s} ... (4702 characters truncated) ... {1!s}',)".format(
                     largeparam[0:149], largeparam[-149:]
                 )
             )
         else:
             eq_(
                 repr(row),
-                "(u'%s ... (4703 characters truncated) ... %s',)" % (
+                "(u'{0!s} ... (4703 characters truncated) ... {1!s}',)".format(
                     largeparam[0:148], largeparam[-149:]
                 )
             )
@@ -301,9 +301,8 @@ class LoggingNameTest(fixtures.TestBase):
         assert self.buf.buffer
         for name in [b.name for b in self.buf.buffer]:
             assert name in (
-                'sqlalchemy.engine.base.Engine.%s' % eng_name,
-                'sqlalchemy.pool.%s.%s' %
-                (eng.pool.__class__.__name__, pool_name)
+                'sqlalchemy.engine.base.Engine.{0!s}'.format(eng_name),
+                'sqlalchemy.pool.{0!s}.{1!s}'.format(eng.pool.__class__.__name__, pool_name)
             )
 
     def _assert_no_name_in_execute(self, eng):
@@ -312,7 +311,7 @@ class LoggingNameTest(fixtures.TestBase):
         for name in [b.name for b in self.buf.buffer]:
             assert name in (
                 'sqlalchemy.engine.base.Engine',
-                'sqlalchemy.pool.%s' % eng.pool.__class__.__name__
+                'sqlalchemy.pool.{0!s}'.format(eng.pool.__class__.__name__)
             )
 
     def _named_engine(self, **kw):

--- a/test/engine/test_parseconnect.py
+++ b/test/engine/test_parseconnect.py
@@ -423,7 +423,7 @@ def MockDBAPI(**assert_kwargs):
 
     def connect(*args, **kwargs):
         for k in assert_kwargs:
-            assert k in kwargs, 'key %s not present in dictionary' % k
+            assert k in kwargs, 'key {0!s} not present in dictionary'.format(k)
             eq_(
                 kwargs[k], assert_kwargs[k]
             )

--- a/test/engine/test_pool.py
+++ b/test/engine/test_pool.py
@@ -733,26 +733,26 @@ class DeprecatedPoolListenerTest(PoolTestBase):
                 eq_((item in self.checked_in), in_cin)
 
             def inst_connect(self, con, record):
-                print("connect(%s, %s)" % (con, record))
+                print("connect({0!s}, {1!s})".format(con, record))
                 assert con is not None
                 assert record is not None
                 self.connected.append(con)
 
             def inst_first_connect(self, con, record):
-                print("first_connect(%s, %s)" % (con, record))
+                print("first_connect({0!s}, {1!s})".format(con, record))
                 assert con is not None
                 assert record is not None
                 self.first_connected.append(con)
 
             def inst_checkout(self, con, record, proxy):
-                print("checkout(%s, %s, %s)" % (con, record, proxy))
+                print("checkout({0!s}, {1!s}, {2!s})".format(con, record, proxy))
                 assert con is not None
                 assert record is not None
                 assert proxy is not None
                 self.checked_out.append(con)
 
             def inst_checkin(self, con, record):
-                print("checkin(%s, %s)" % (con, record))
+                print("checkin({0!s}, {1!s})".format(con, record))
                 # con can be None if invalidated
                 assert record is not None
                 self.checked_in.append(con)
@@ -1054,10 +1054,10 @@ class QueuePoolTest(PoolTestBase):
 
         assert len(timeouts) > 0
         for t in timeouts:
-            assert t >= 3, "Not all timeouts were >= 3 seconds %r" % timeouts
+            assert t >= 3, "Not all timeouts were >= 3 seconds {0!r}".format(timeouts)
             # normally, the timeout should under 4 seconds,
             # but on a loaded down buildbot it can go up.
-            assert t < 14, "Not all timeouts were < 14 seconds %r" % timeouts
+            assert t < 14, "Not all timeouts were < 14 seconds {0!r}".format(timeouts)
 
     def _test_overflow(self, thread_count, max_overflow):
         gc_collect()
@@ -1233,7 +1233,7 @@ class QueuePoolTest(PoolTestBase):
                 for t in threads:
                     t.join(join_timeout)
 
-        eq_(len(success), 12, "successes: %s" % success)
+        eq_(len(success), 12, "successes: {0!s}".format(success))
 
     def test_connrec_invalidated_within_checkout_no_race(self):
         """Test that a concurrent ConnectionRecord.invalidate() which

--- a/test/engine/test_reconnect.py
+++ b/test/engine/test_reconnect.py
@@ -742,7 +742,7 @@ class InvalidateDuringResultTest(fixtures.TestBase):
             Column('name', String(50)))
         self.meta.create_all()
         table.insert().execute(
-            [{'id': i, 'name': 'row %d' % i} for i in range(1, 100)]
+            [{'id': i, 'name': 'row {0:d}'.format(i)} for i in range(1, 100)]
         )
 
     def teardown(self):

--- a/test/engine/test_reflection.py
+++ b/test/engine/test_reflection.py
@@ -823,8 +823,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
         Table('false', meta,
                     Column('create', sa.Integer, primary_key=True),
                     Column('true', sa.Integer, sa.ForeignKey('select.not')),
-                    sa.CheckConstraint('%s <> 1'
-                        % quoter(check_col), name='limit')
+                    sa.CheckConstraint('{0!s} <> 1'.format(quoter(check_col)), name='limit')
                     )
 
         table_c = Table('is', meta,
@@ -871,7 +870,7 @@ class ReflectionTest(fixtures.TestBase, ComparesTables):
     def test_reflect_all(self):
         existing = testing.db.table_names()
 
-        names = ['rt_%s' % name for name in ('a', 'b', 'c', 'd', 'e')]
+        names = ['rt_{0!s}'.format(name) for name in ('a', 'b', 'c', 'd', 'e')]
         nameset = set(names)
         for name in names:
             # be sure our starting environment is sane
@@ -1261,7 +1260,7 @@ class UnicodeReflectionTest(fixtures.TestBase):
     @testing.requires.unicode_connections
     def test_has_table(self):
         for tname, cname, ixname in self.names:
-            assert testing.db.has_table(tname), "Can't detect name %s" % tname
+            assert testing.db.has_table(tname), "Can't detect name {0!s}".format(tname)
 
     @testing.requires.unicode_connections
     def test_basic(self):
@@ -1346,7 +1345,7 @@ class SchemaTest(fixtures.TestBase):
             eq_(set(meta2.tables), set(
                 [
                     'some_other_table',
-                    '%s.some_table' % testing.config.test_schema]))
+                    '{0!s}.some_table'.format(testing.config.test_schema)]))
 
     @testing.requires.schemas
     @testing.fails_on('sqlite', 'FIXME: unknown')
@@ -1373,7 +1372,7 @@ class SchemaTest(fixtures.TestBase):
         Table('table2', metadata,
                        Column('col1', sa.Integer, primary_key=True),
                        Column('col2', sa.Integer,
-                              sa.ForeignKey('%s.table1.col1' % schema)),
+                              sa.ForeignKey('{0!s}.table1.col1'.format(schema))),
                        test_needs_fk=True,
                        schema=schema)
         try:
@@ -1447,9 +1446,9 @@ class SchemaTest(fixtures.TestBase):
         eq_(
             set(m2.tables),
             set([
-                '%s.dingalings' % testing.config.test_schema,
-                '%s.users' % testing.config.test_schema,
-                '%s.email_addresses' % testing.config.test_schema
+                '{0!s}.dingalings'.format(testing.config.test_schema),
+                '{0!s}.users'.format(testing.config.test_schema),
+                '{0!s}.email_addresses'.format(testing.config.test_schema)
                 ])
         )
 
@@ -1498,7 +1497,7 @@ def createTables(meta, schema=None):
         Column('test5', sa.Date),
         Column('test5_1', sa.TIMESTAMP),
         Column('parent_user_id', sa.Integer,
-                    sa.ForeignKey('%susers.user_id' % schema_prefix)),
+                    sa.ForeignKey('{0!s}users.user_id'.format(schema_prefix))),
         Column('test6', sa.Date, nullable=False),
         Column('test7', sa.Text),
         Column('test8', sa.LargeBinary),
@@ -1512,7 +1511,7 @@ def createTables(meta, schema=None):
                 Column('dingaling_id', sa.Integer, primary_key=True),
                 Column('address_id', sa.Integer,
                      sa.ForeignKey(
-                         '%semail_addresses.address_id' % schema_prefix)),
+                         '{0!s}email_addresses.address_id'.format(schema_prefix))),
                 Column('data', sa.String(30)),
                 schema=schema, test_needs_fk=True,
             )
@@ -1532,8 +1531,8 @@ def createTables(meta, schema=None):
 def createIndexes(con, schema=None):
     fullname = 'users'
     if schema:
-        fullname = "%s.%s" % (schema, 'users')
-    query = "CREATE INDEX users_t_idx ON %s (test1, test2)" % fullname
+        fullname = "{0!s}.{1!s}".format(schema, 'users')
+    query = "CREATE INDEX users_t_idx ON {0!s} (test1, test2)".format(fullname)
     con.execute(sa.sql.text(query))
 
 
@@ -1542,9 +1541,9 @@ def _create_views(con, schema=None):
     for table_name in ('users', 'email_addresses'):
         fullname = table_name
         if schema:
-            fullname = "%s.%s" % (schema, table_name)
+            fullname = "{0!s}.{1!s}".format(schema, table_name)
         view_name = fullname + '_v'
-        query = "CREATE VIEW %s AS SELECT * FROM %s" % (view_name, fullname)
+        query = "CREATE VIEW {0!s} AS SELECT * FROM {1!s}".format(view_name, fullname)
         con.execute(sa.sql.text(query))
 
 
@@ -1553,9 +1552,9 @@ def _drop_views(con, schema=None):
     for table_name in ('email_addresses', 'users'):
         fullname = table_name
         if schema:
-            fullname = "%s.%s" % (schema, table_name)
+            fullname = "{0!s}.{1!s}".format(schema, table_name)
         view_name = fullname + '_v'
-        query = "DROP VIEW %s" % view_name
+        query = "DROP VIEW {0!s}".format(view_name)
         con.execute(sa.sql.text(query))
 
 

--- a/test/engine/test_transaction.py
+++ b/test/engine/test_transaction.py
@@ -953,7 +953,7 @@ class TLTransactionTest(fixtures.TestBase):
         transaction = connection.begin()
         result = connection.execute('select * from query_users')
         l = result.fetchall()
-        assert len(l) == 3, 'expected 3 got %d' % len(l)
+        assert len(l) == 3, 'expected 3 got {0:d}'.format(len(l))
         transaction.commit()
         connection.close()
 

--- a/test/ext/declarative/test_basic.py
+++ b/test/ext/declarative/test_basic.py
@@ -553,9 +553,8 @@ class DeclarativeTest(DeclarativeTestBase):
             __tablename__ = 'users'
             id = Column(Integer, primary_key=True)
             addresses = relationship(
-                '%s.Address' % __name__,
-                primaryjoin='%s.User.id==%s.Address.user_id.prop.columns[0]'
-                % (__name__, __name__))
+                '{0!s}.Address'.format(__name__),
+                primaryjoin='{0!s}.User.id=={1!s}.Address.user_id.prop.columns[0]'.format(__name__, __name__))
 
         class Address(Base, fixtures.ComparableEntity):
 
@@ -1812,7 +1811,7 @@ def _produce_test(inline, stringbased):
                 User.addresses.any(Address.email == 'jack@bean.com')).all(),
                 [])
 
-    ExplicitJoinTest.__name__ = 'ExplicitJoinTest%s%s' % (
+    ExplicitJoinTest.__name__ = 'ExplicitJoinTest{0!s}{1!s}'.format(
         inline and 'Inline' or 'Separate',
         stringbased and 'String' or 'Literal')
     return ExplicitJoinTest
@@ -1820,5 +1819,5 @@ def _produce_test(inline, stringbased):
 for inline in True, False:
     for stringbased in True, False:
         testclass = _produce_test(inline, stringbased)
-        exec('%s = testclass' % testclass.__name__)
+        exec('{0!s} = testclass'.format(testclass.__name__))
         del testclass

--- a/test/ext/declarative/test_mixin.py
+++ b/test/ext/declarative/test_mixin.py
@@ -1343,8 +1343,7 @@ class DeclarativeMixinPropertyTest(DeclarativeTestBase):
                 @declared_attr
                 def target(cls):
                     return relationship('Target',
-                                        primaryjoin='Target.id==%s.target_id'
-                                        % cls.__name__)
+                                        primaryjoin='Target.id=={0!s}.target_id'.format(cls.__name__))
             else:
 
                 @declared_attr

--- a/test/ext/test_associationproxy.py
+++ b/test/ext/test_associationproxy.py
@@ -517,7 +517,7 @@ class SetTest(_CollectionOperations):
                     try:
                         self.assert_(p.children == control)
                     except:
-                        print('Test %s.%s(%s):' % (set(base), op, other))
+                        print('Test {0!s}.{1!s}({2!s}):'.format(set(base), op, other))
                         print('want', repr(control))
                         print('got', repr(p.children))
                         raise
@@ -527,7 +527,7 @@ class SetTest(_CollectionOperations):
                     try:
                         self.assert_(p.children == control)
                     except:
-                        print('Test %s.%s(%s):' % (base, op, other))
+                        print('Test {0!s}.{1!s}({2!s}):'.format(base, op, other))
                         print('want', repr(control))
                         print('got', repr(p.children))
                         raise
@@ -544,13 +544,13 @@ class SetTest(_CollectionOperations):
                     p.children = base[:]
                     control = set(base[:])
 
-                    exec("p.children %s other" % op)
-                    exec("control %s other" % op)
+                    exec("p.children {0!s} other".format(op))
+                    exec("control {0!s} other".format(op))
 
                     try:
                         self.assert_(p.children == control)
                     except:
-                        print('Test %s %s %s:' % (set(base), op, other))
+                        print('Test {0!s} {1!s} {2!s}:'.format(set(base), op, other))
                         print('want', repr(control))
                         print('got', repr(p.children))
                         raise
@@ -560,7 +560,7 @@ class SetTest(_CollectionOperations):
                     try:
                         self.assert_(p.children == control)
                     except:
-                        print('Test %s %s %s:' % (base, op, other))
+                        print('Test {0!s} {1!s} {2!s}:'.format(base, op, other))
                         print('want', repr(control))
                         print('got', repr(p.children))
                         raise
@@ -1190,10 +1190,10 @@ class ComparatorTest(fixtures.MappedTest, AssertsCompiledSQL):
             'the', 'lazy',
             )
         for ii in range(16):
-            user = User('user%d' % ii)
+            user = User('user{0:d}'.format(ii))
 
             if ii % 2 == 0:
-                user.singular = Singular(value=("singular%d" % ii)
+                user.singular = Singular(value=("singular{0:d}".format(ii))
                                         if ii % 4 == 0 else None)
             session.add(user)
             for jj in words[(ii % len(words)):((ii + 3) % len(words))]:
@@ -1201,7 +1201,7 @@ class ComparatorTest(fixtures.MappedTest, AssertsCompiledSQL):
                 user.keywords.append(k)
                 if ii % 2 == 0:
                     user.singular.keywords.append(k)
-                    user.user_keywords[-1].value = "singular%d" % ii
+                    user.user_keywords[-1].value = "singular{0:d}".format(ii)
 
         orphan = Keyword('orphan')
         orphan.user_keyword = UserKeyword(keyword=orphan, user=None)

--- a/test/ext/test_compiler.py
+++ b/test/ext/test_compiler.py
@@ -24,7 +24,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
 
         @compiles(MyThingy)
         def visit_thingy(thingy, compiler, **kw):
-            return ">>%s<<" % thingy.name
+            return ">>{0!s}<<".format(thingy.name)
 
         self.assert_compile(
             select([column('foo'), MyThingy()]),
@@ -110,7 +110,7 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
 
         @compiles(InsertFromSelect)
         def visit_insert_from_select(element, compiler, **kw):
-            return "INSERT INTO %s (%s)" % (
+            return "INSERT INTO {0!s} ({1!s})".format(
                 compiler.process(element.table, asfrom=True),
                 compiler.process(element.select)
             )
@@ -298,11 +298,11 @@ class UserDefinedTest(fixtures.TestBase, AssertsCompiledSQL):
         @compiles(greatest, 'mssql')
         def case_greatest(element, compiler, **kw):
             arg1, arg2 = list(element.clauses)
-            return "CASE WHEN %s > %s THEN %s ELSE %s END" % (
+            return "CASE WHEN {0!s} > {1!s} THEN {2!s} ELSE {3!s} END".format(
                 compiler.process(arg1),
                 compiler.process(arg2),
                 compiler.process(arg1),
-                compiler.process(arg2),
+                compiler.process(arg2)
             )
 
         self.assert_compile(
@@ -410,7 +410,7 @@ class DefaultOnExistingTest(fixtures.TestBase, AssertsCompiledSQL):
 
         @compiles(BindParameter)
         def gen_bind(element, compiler, **kw):
-            return "BIND(%s)" % compiler.visit_bindparam(element, **kw)
+            return "BIND({0!s})".format(compiler.visit_bindparam(element, **kw))
 
         self.assert_compile(
             t.select().where(t.c.c == 5),
@@ -427,7 +427,7 @@ class DefaultOnExistingTest(fixtures.TestBase, AssertsCompiledSQL):
 
         @compiles(BindParameter)
         def gen_bind(element, compiler, **kw):
-            return "BIND(%s)" % compiler.visit_bindparam(element, **kw)
+            return "BIND({0!s})".format(compiler.visit_bindparam(element, **kw))
 
         self.assert_compile(
             t.insert(),

--- a/test/ext/test_horizontal_shard.py
+++ b/test/ext/test_horizontal_shard.py
@@ -227,7 +227,7 @@ class DistinctEngineShardTest(ShardTest, fixtures.TestBase):
         for db in (db1, db2, db3, db4):
             db.connect().invalidate()
         for i in range(1, 5):
-            os.remove("shard%d.db" % i)
+            os.remove("shard{0:d}.db".format(i))
 
 class AttachedFileShardTest(ShardTest, fixtures.TestBase):
     schema = "changeme"

--- a/test/ext/test_hybrid.py
+++ b/test/ext/test_hybrid.py
@@ -498,10 +498,10 @@ class SpecialObjectTest(fixtures.TestBase, AssertsCompiledSQL):
                     return self.amount
 
             def __str__(self):
-                return "%2.4f %s" % (self.amount, self.currency)
+                return "{0:2.4f} {1!s}".format(self.amount, self.currency)
 
             def __repr__(self):
-                return "Amount(%r, %r)" % (self.amount, self.currency)
+                return "Amount({0!r}, {1!r})".format(self.amount, self.currency)
 
         Base = declarative_base()
 

--- a/test/ext/test_orderinglist.py
+++ b/test/ext/test_orderinglist.py
@@ -69,13 +69,13 @@ class OrderingListTest(fixtures.TestBase):
             def __init__(self, name):
                 self.name = name
             def __repr__(self):
-                return '<Slide "%s">' % self.name
+                return '<Slide "{0!s}">'.format(self.name)
 
         class Bullet(object):
             def __init__(self, text):
                 self.text = text
             def __repr__(self):
-                return '<Bullet "%s" pos %s>' % (self.text, self.position)
+                return '<Bullet "{0!s}" pos {1!s}>'.format(self.text, self.position)
 
         mapper(Slide, slides_table, properties={
             'bullets': relationship(Bullet, lazy='joined',

--- a/test/orm/inheritance/test_abc_inheritance.py
+++ b/test/orm/inheritance/test_abc_inheritance.py
@@ -23,9 +23,9 @@ def produce_test(parent, child, direction):
             ta.append(Column('id', Integer, primary_key=True, test_needs_autoincrement=True)),
             ta.append(Column('a_data', String(30)))
             if "a"== parent and direction == MANYTOONE:
-                ta.append(Column('child_id', Integer, ForeignKey("%s.id" % child, use_alter=True, name="foo")))
+                ta.append(Column('child_id', Integer, ForeignKey("{0!s}.id".format(child), use_alter=True, name="foo")))
             elif "a" == child and direction == ONETOMANY:
-                ta.append(Column('parent_id', Integer, ForeignKey("%s.id" % parent, use_alter=True, name="foo")))
+                ta.append(Column('parent_id', Integer, ForeignKey("{0!s}.id".format(parent), use_alter=True, name="foo")))
             ta = Table(*ta)
 
             tb = ["b", metadata]
@@ -34,9 +34,9 @@ def produce_test(parent, child, direction):
             tb.append(Column('b_data', String(30)))
 
             if "b"== parent and direction == MANYTOONE:
-                tb.append(Column('child_id', Integer, ForeignKey("%s.id" % child, use_alter=True, name="foo")))
+                tb.append(Column('child_id', Integer, ForeignKey("{0!s}.id".format(child), use_alter=True, name="foo")))
             elif "b" == child and direction == ONETOMANY:
-                tb.append(Column('parent_id', Integer, ForeignKey("%s.id" % parent, use_alter=True, name="foo")))
+                tb.append(Column('parent_id', Integer, ForeignKey("{0!s}.id".format(parent), use_alter=True, name="foo")))
             tb = Table(*tb)
 
             tc = ["c", metadata]
@@ -45,9 +45,9 @@ def produce_test(parent, child, direction):
             tc.append(Column('c_data', String(30)))
 
             if "c"== parent and direction == MANYTOONE:
-                tc.append(Column('child_id', Integer, ForeignKey("%s.id" % child, use_alter=True, name="foo")))
+                tc.append(Column('child_id', Integer, ForeignKey("{0!s}.id".format(child), use_alter=True, name="foo")))
             elif "c" == child and direction == ONETOMANY:
-                tc.append(Column('parent_id', Integer, ForeignKey("%s.id" % parent, use_alter=True, name="foo")))
+                tc.append(Column('parent_id', Integer, ForeignKey("{0!s}.id".format(parent), use_alter=True, name="foo")))
             tc = Table(*tc)
 
         def teardown(self):
@@ -167,7 +167,7 @@ def produce_test(parent, child, direction):
                 assert result2.id == parent2.id
                 assert result2.collection[0].id == child_obj.id
 
-    ABCTest.__name__ = "Test%sTo%s%s" % (parent, child, (direction is ONETOMANY and "O2M" or "M2O"))
+    ABCTest.__name__ = "Test{0!s}To{1!s}{2!s}".format(parent, child, (direction is ONETOMANY and "O2M" or "M2O"))
     return ABCTest
 
 # test all combinations of polymorphic a/b/c related to another of a/b/c
@@ -175,7 +175,7 @@ for parent in ["a", "b", "c"]:
     for child in ["a", "b", "c"]:
         for direction in [ONETOMANY, MANYTOONE]:
             testclass = produce_test(parent, child, direction)
-            exec("%s = testclass" % testclass.__name__)
+            exec("{0!s} = testclass".format(testclass.__name__))
             del testclass
 
 del produce_test

--- a/test/orm/inheritance/test_abc_polymorphic.py
+++ b/test/orm/inheritance/test_abc_polymorphic.py
@@ -83,7 +83,7 @@ class ABCTest(fixtures.MappedTest):
             ], sess.query(C).order_by(A.id).all())
 
         test_roundtrip = function_named(
-            test_roundtrip, 'test_%s' % fetchtype)
+            test_roundtrip, 'test_{0!s}'.format(fetchtype))
         return test_roundtrip
 
     test_union = _make_test('union')

--- a/test/orm/inheritance/test_assorted_poly.py
+++ b/test/orm/inheritance/test_assorted_poly.py
@@ -21,7 +21,7 @@ class AttrSettable(object):
     def __init__(self, **kwargs):
         [setattr(self, k, v) for k, v in kwargs.items()]
     def __repr__(self):
-        return self.__class__.__name__ + "(%s)" % (hex(id(self)))
+        return self.__class__.__name__ + "({0!s})".format((hex(id(self))))
 
 
 class RelationshipTest1(fixtures.MappedTest):
@@ -342,7 +342,7 @@ def _generate_test(jointype="join1", usedata=False):
             assert m.data.data == 'ms data'
 
     do_test = function_named(
-        _do_test, 'test_relationship_on_base_class_%s_%s' % (
+        _do_test, 'test_relationship_on_base_class_{0!s}_{1!s}'.format(
         jointype, data and "nodata" or "data"))
     return do_test
 
@@ -390,21 +390,19 @@ class RelationshipTest4(fixtures.MappedTest):
                 for key, value in kwargs.items():
                     setattr(self, key, value)
             def __repr__(self):
-                return "Ordinary person %s" % self.name
+                return "Ordinary person {0!s}".format(self.name)
         class Engineer(Person):
             def __repr__(self):
-                return "Engineer %s, status %s" % \
-                        (self.name, self.status)
+                return "Engineer {0!s}, status {1!s}".format(self.name, self.status)
         class Manager(Person):
             def __repr__(self):
-                return "Manager %s, status %s" % \
-                        (self.name, self.longer_status)
+                return "Manager {0!s}, status {1!s}".format(self.name, self.longer_status)
         class Car(object):
             def __init__(self, **kwargs):
                 for key, value in kwargs.items():
                     setattr(self, key, value)
             def __repr__(self):
-                return "Car number %d" % self.car_id
+                return "Car number {0:d}".format(self.car_id)
 
         # create a union that represents both types of joins.
         employee_join = polymorphic_union(
@@ -431,11 +429,11 @@ class RelationshipTest4(fixtures.MappedTest):
 
         # creating 5 managers named from M1 to E5
         for i in range(1,5):
-            session.add(Manager(name="M%d" % i,
+            session.add(Manager(name="M{0:d}".format(i),
                                 longer_status="YYYYYYYYY"))
         # creating 5 engineers named from E1 to E5
         for i in range(1,5):
-            session.add(Engineer(name="E%d" % i,status="X"))
+            session.add(Engineer(name="E{0:d}".format(i),status="X"))
 
         session.flush()
 
@@ -516,21 +514,19 @@ class RelationshipTest5(fixtures.MappedTest):
                 for key, value in kwargs.items():
                     setattr(self, key, value)
             def __repr__(self):
-                return "Ordinary person %s" % self.name
+                return "Ordinary person {0!s}".format(self.name)
         class Engineer(Person):
             def __repr__(self):
-                return "Engineer %s, status %s" % \
-                        (self.name, self.status)
+                return "Engineer {0!s}, status {1!s}".format(self.name, self.status)
         class Manager(Person):
             def __repr__(self):
-                return "Manager %s, status %s" % \
-                        (self.name, self.longer_status)
+                return "Manager {0!s}, status {1!s}".format(self.name, self.longer_status)
         class Car(object):
             def __init__(self, **kwargs):
                 for key, value in kwargs.items():
                     setattr(self, key, value)
             def __repr__(self):
-                return "Car number %d" % self.car_id
+                return "Car number {0:d}".format(self.car_id)
 
         person_mapper   = mapper(Person, people,
                                     polymorphic_on=people.c.type,
@@ -652,31 +648,29 @@ class RelationshipTest7(fixtures.MappedTest):
 
         class Status(PersistentObject):
             def __repr__(self):
-                return "Status %s" % self.name
+                return "Status {0!s}".format(self.name)
 
         class Person(PersistentObject):
             def __repr__(self):
-                return "Ordinary person %s" % self.name
+                return "Ordinary person {0!s}".format(self.name)
 
         class Engineer(Person):
             def __repr__(self):
-                return "Engineer %s, field %s" % (self.name,
+                return "Engineer {0!s}, field {1!s}".format(self.name,
                                                 self.field)
 
         class Manager(Person):
             def __repr__(self):
-                return "Manager %s, category %s" % (self.name,
+                return "Manager {0!s}, category {1!s}".format(self.name,
                                                 self.category)
 
         class Car(PersistentObject):
             def __repr__(self):
-                return "Car number %d, name %s" % \
-                                        (self.car_id, self.name)
+                return "Car number {0:d}, name {1!s}".format(self.car_id, self.name)
 
         class Offraod_Car(Car):
             def __repr__(self):
-                return "Offroad Car number %d, name %s" % \
-                                        (self.car_id,self.name)
+                return "Offroad Car number {0:d}, name {1!s}".format(self.car_id, self.name)
 
         employee_join = polymorphic_union(
                 {
@@ -720,9 +714,9 @@ class RelationshipTest7(fixtures.MappedTest):
                 car=Car()
             else:
                 car=Offraod_Car()
-            session.add(Manager(name="M%d" % i,
+            session.add(Manager(name="M{0:d}".format(i),
                                 category="YYYYYYYYY",car=car))
-            session.add(Engineer(name="E%d" % i,field="X",car=car))
+            session.add(Engineer(name="E{0:d}".format(i),field="X",car=car))
             session.flush()
             session.expunge_all()
 
@@ -843,21 +837,21 @@ class GenerativeTest(fixtures.TestBase, AssertsExecutionResults):
                     setattr(self, key, value)
         class Status(PersistentObject):
             def __repr__(self):
-                return "Status %s" % self.name
+                return "Status {0!s}".format(self.name)
         class Person(PersistentObject):
             def __repr__(self):
-                return "Ordinary person %s" % self.name
+                return "Ordinary person {0!s}".format(self.name)
         class Engineer(Person):
             def __repr__(self):
-                return "Engineer %s, field %s, status %s" % (
+                return "Engineer {0!s}, field {1!s}, status {2!s}".format(
                                         self.name, self.field, self.status)
         class Manager(Person):
             def __repr__(self):
-                return "Manager %s, category %s, status %s" % (
+                return "Manager {0!s}, category {1!s}, status {2!s}".format(
                                         self.name, self.category, self.status)
         class Car(PersistentObject):
             def __repr__(self):
-                return "Car number %d" % self.car_id
+                return "Car number {0:d}".format(self.car_id)
 
         # create a union that represents both types of joins.
         employee_join = polymorphic_union(
@@ -902,9 +896,9 @@ class GenerativeTest(fixtures.TestBase, AssertsExecutionResults):
                 st=active
             else:
                 st=dead
-            session.add(Manager(name="M%d" % i,
+            session.add(Manager(name="M{0:d}".format(i),
                                 category="YYYYYYYYY",status=st))
-            session.add(Engineer(name="E%d" % i,field="X",status=st))
+            session.add(Engineer(name="E{0:d}".format(i),field="X",status=st))
 
         session.flush()
 

--- a/test/orm/inheritance/test_basic.py
+++ b/test/orm/inheritance/test_basic.py
@@ -40,18 +40,18 @@ class O2MTest(fixtures.MappedTest):
             def __init__(self, data=None):
                 self.data = data
             def __repr__(self):
-                return "Foo id %d, data %s" % (self.id, self.data)
+                return "Foo id {0:d}, data {1!s}".format(self.id, self.data)
         mapper(Foo, foo)
 
         class Bar(Foo):
             def __repr__(self):
-                return "Bar id %d, data %s" % (self.id, self.data)
+                return "Bar id {0:d}, data {1!s}".format(self.id, self.data)
 
         mapper(Bar, bar, inherits=Foo)
 
         class Blub(Bar):
             def __repr__(self):
-                return "Blub id %d, data %s" % (self.id, self.data)
+                return "Blub id {0:d}, data {1!s}".format(self.id, self.data)
 
         mapper(Blub, blub, inherits=Bar, properties={
             'parent_foo':relationship(Foo)
@@ -405,7 +405,7 @@ class PolymorphicOnNotLocalTest(fixtures.MappedTest):
                 elif ident == 'child':
                     instance.x = child_ident
                 else:
-                    assert False, "Got unexpected identity %r" % ident
+                    assert False, "Got unexpected identity {0!r}".format(ident)
 
         s = Session(testing.db)
         s.add_all([

--- a/test/orm/inheritance/test_magazine.py
+++ b/test/orm/inheritance/test_magazine.py
@@ -18,7 +18,7 @@ class Issue(BaseObject):
 
 class Location(BaseObject):
     def __repr__(self):
-        return "%s(%s, %s)" % (self.__class__.__name__, str(getattr(self, 'issue_id', None)), repr(str(self._name.name)))
+        return "{0!s}({1!s}, {2!s})".format(self.__class__.__name__, str(getattr(self, 'issue_id', None)), repr(str(self._name.name)))
 
     def _get_name(self):
         return self._name
@@ -48,23 +48,23 @@ class Location(BaseObject):
 
 class LocationName(BaseObject):
     def __repr__(self):
-        return "%s()" % (self.__class__.__name__)
+        return "{0!s}()".format((self.__class__.__name__))
 
 class PageSize(BaseObject):
     def __repr__(self):
-        return "%s(%sx%s, %s)" % (self.__class__.__name__, self.width, self.height, self.name)
+        return "{0!s}({1!s}x{2!s}, {3!s})".format(self.__class__.__name__, self.width, self.height, self.name)
 
 class Magazine(BaseObject):
     def __repr__(self):
-        return "%s(%s, %s)" % (self.__class__.__name__, repr(self.location), repr(self.size))
+        return "{0!s}({1!s}, {2!s})".format(self.__class__.__name__, repr(self.location), repr(self.size))
 
 class Page(BaseObject):
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, str(self.page_no))
+        return "{0!s}({1!s})".format(self.__class__.__name__, str(self.page_no))
 
 class MagazinePage(Page):
     def __repr__(self):
-        return "%s(%s, %s)" % (self.__class__.__name__, str(self.page_no), repr(self.magazine))
+        return "{0!s}({1!s}, {2!s})".format(self.__class__.__name__, str(self.page_no), repr(self.magazine))
 
 class ClassifiedPage(MagazinePage):
     pass
@@ -212,7 +212,7 @@ def _generate_round_trip_test(use_unions=False, use_joins=False):
         assert repr(p.issues[0].locations[0].magazine.pages) == repr([page, page2, page3]), repr(p.issues[0].locations[0].magazine.pages)
 
     test_roundtrip = function_named(
-        test_roundtrip, "test_%s" % (not use_union and (use_joins and "joins" or "select") or "unions"))
+        test_roundtrip, "test_{0!s}".format((not use_union and (use_joins and "joins" or "select") or "unions")))
     setattr(MagazineTest, test_roundtrip.__name__, test_roundtrip)
 
 for (use_union, use_join) in [(True, False), (False, True), (False, False)]:

--- a/test/orm/inheritance/test_manytomany.py
+++ b/test/orm/inheritance/test_manytomany.py
@@ -177,12 +177,12 @@ class InheritTest3(fixtures.MappedTest):
             def __init__(self, data=None):
                 self.data = data
             def __repr__(self):
-                return "Foo id %d, data %s" % (self.id, self.data)
+                return "Foo id {0:d}, data {1!s}".format(self.id, self.data)
         mapper(Foo, foo)
 
         class Bar(Foo):
             def __repr__(self):
-                return "Bar id %d, data %s" % (self.id, self.data)
+                return "Bar id {0:d}, data {1!s}".format(self.id, self.data)
 
         mapper(Bar, bar, inherits=Foo, properties={
             'foos' :relationship(Foo, secondary=bar_foo, lazy='select')
@@ -206,17 +206,17 @@ class InheritTest3(fixtures.MappedTest):
             def __init__(self, data=None):
                 self.data = data
             def __repr__(self):
-                return "Foo id %d, data %s" % (self.id, self.data)
+                return "Foo id {0:d}, data {1!s}".format(self.id, self.data)
         mapper(Foo, foo)
 
         class Bar(Foo):
             def __repr__(self):
-                return "Bar id %d, data %s" % (self.id, self.data)
+                return "Bar id {0:d}, data {1!s}".format(self.id, self.data)
         mapper(Bar, bar, inherits=Foo)
 
         class Blub(Bar):
             def __repr__(self):
-                return "Blub id %d, data %s, bars %s, foos %s" % (
+                return "Blub id {0:d}, data {1!s}, bars {2!s}, foos {3!s}".format(
                         self.id, self.data, repr([b for b in self.bars]),
                         repr([f for f in self.foos]))
 

--- a/test/orm/inheritance/test_poly_linked_list.py
+++ b/test/orm/inheritance/test_poly_linked_list.py
@@ -49,7 +49,7 @@ class PolymorphicCircularTest(fixtures.MappedTest):
                 if data is not None:
                     self.data = data
             def __repr__(self):
-                return "%s(%s, %s, %s)" % (self.__class__.__name__, self.id, repr(str(self.name)), repr(self.data))
+                return "{0!s}({1!s}, {2!s}, {3!s})".format(self.__class__.__name__, self.id, repr(str(self.name)), repr(self.data))
 
         class Table1B(Table1):
             pass
@@ -64,7 +64,7 @@ class PolymorphicCircularTest(fixtures.MappedTest):
             def __init__(self, data):
                 self.data = data
             def __repr__(self):
-                return "%s(%s, %s)" % (self.__class__.__name__, self.id, repr(str(self.data)))
+                return "{0!s}({1!s}, {2!s})".format(self.__class__.__name__, self.id, repr(str(self.data)))
 
         try:
             # this is how the mapping used to work.  ensure that this raises an error now
@@ -138,7 +138,7 @@ class PolymorphicCircularTest(fixtures.MappedTest):
         obj = None
         for c in classes:
             if isinstance(c, type):
-                newobj = c('item %d' % count)
+                newobj = c('item {0:d}'.format(count))
                 count += 1
             else:
                 newobj = c

--- a/test/orm/inheritance/test_poly_persistence.py
+++ b/test/orm/inheritance/test_poly_persistence.py
@@ -338,7 +338,7 @@ def _generate_round_trip_test(include_base, lazy_relationship,
         eq_(select([func.count('*')]).select_from(people).scalar(), 0)
 
     test_roundtrip = function_named(
-        test_roundtrip, "test_%s%s%s_%s" % (
+        test_roundtrip, "test_{0!s}{1!s}{2!s}_{3!s}".format(
           (lazy_relationship and "lazy" or "eager"),
           (include_base and "_inclbase" or ""),
           (redefine_colprop and "_redefcol" or ""),

--- a/test/orm/inheritance/test_productspec.py
+++ b/test/orm/inheritance/test_productspec.py
@@ -46,7 +46,7 @@ class InheritTest(fixtures.MappedTest):
                 self.name = name
                 self.mark = mark
             def __repr__(self):
-                return '<%s %s>' % (self.__class__.__name__, self.name)
+                return '<{0!s} {1!s}>'.format(self.__class__.__name__, self.name)
 
         class Detail(Product):
             def __init__(self, name):
@@ -63,7 +63,7 @@ class InheritTest(fixtures.MappedTest):
                 self.quantity = quantity
 
             def __repr__(self):
-                return '<%s %.01f %s>' % (
+                return '<{0!s} {1:.01f} {2!s}>'.format(
                     self.__class__.__name__,
                     self.quantity or 0.,
                     repr(self.slave)
@@ -74,7 +74,7 @@ class InheritTest(fixtures.MappedTest):
                 self.name = name
                 self.data = data
             def __repr__(self):
-                return '<%s %s>' % (self.__class__.__name__, self.name)
+                return '<{0!s} {1!s}>'.format(self.__class__.__name__, self.name)
 
         class RasterDocument(Document):
             pass

--- a/test/orm/inheritance/test_relationship.py
+++ b/test/orm/inheritance/test_relationship.py
@@ -288,7 +288,7 @@ class SelfReferentialJ2JSelfTest(fixtures.MappedTest):
     def _five_obj_fixture(self):
         sess = Session()
         e1, e2, e3, e4, e5 = [
-            Engineer(name='e%d' % (i + 1)) for i in range(5)
+            Engineer(name='e{0:d}'.format((i + 1))) for i in range(5)
         ]
         e3.reports_to = e1
         e4.reports_to = e2

--- a/test/orm/test_association.py
+++ b/test/orm/test_association.py
@@ -30,21 +30,21 @@ class AssociationTest(fixtures.MappedTest):
             def __init__(self, name):
                 self.name = name
             def __repr__(self):
-                return "Item id=%d name=%s keywordassoc=%r" % (
+                return "Item id={0:d} name={1!s} keywordassoc={2!r}".format(
                     self.item_id, self.name, self.keywords)
 
         class Keyword(cls.Basic):
             def __init__(self, name):
                 self.name = name
             def __repr__(self):
-                return "Keyword id=%d name=%s" % (self.keyword_id, self.name)
+                return "Keyword id={0:d} name={1!s}".format(self.keyword_id, self.name)
 
         class KeywordAssociation(cls.Basic):
             def __init__(self, keyword, data):
                 self.keyword = keyword
                 self.data = data
             def __repr__(self):
-                return "KeywordAssociation itemid=%d keyword=%r data=%s" % (
+                return "KeywordAssociation itemid={0:d} keyword={1!r} data={2!s}".format(
                     self.item_id, self.keyword, self.data)
 
     @classmethod

--- a/test/orm/test_assorted_eager.py
+++ b/test/orm/test_assorted_eager.py
@@ -157,7 +157,7 @@ class EagerTest(fixtures.MappedTest):
                             sa.or_(options.c.someoption==None,
                                    options.c.someoption==False))))
 
-        result = ["%d %s" % ( t.id,t.category.name ) for t in l]
+        result = ["{0:d} {1!s}".format(t.id, t.category.name ) for t in l]
         eq_(result, ['1 Some Category', '3 Some Category'])
 
     def test_withjoinedload(self):
@@ -184,7 +184,7 @@ class EagerTest(fixtures.MappedTest):
                           sa.or_(options.c.someoption==None,
                                  options.c.someoption==False))))
 
-        result = ["%d %s" % ( t.id,t.category.name ) for t in l]
+        result = ["{0:d} {1!s}".format(t.id, t.category.name ) for t in l]
         eq_(result, ['1 Some Category', '3 Some Category'])
 
     def test_dslish(self):
@@ -202,7 +202,7 @@ class EagerTest(fixtures.MappedTest):
                            options.c.someoption == False))
             ).outerjoin('owner_option')
 
-        result = ["%d %s" % ( t.id,t.category.name ) for t in l]
+        result = ["{0:d} {1!s}".format(t.id, t.category.name ) for t in l]
         eq_(result, ['1 Some Category', '3 Some Category'])
 
     @testing.crashes('sybase', 'FIXME: unknown, verify not fails_on')
@@ -215,10 +215,10 @@ class EagerTest(fixtures.MappedTest):
         q = s.query(Thing).options(sa.orm.joinedload('category'))
         l = (q.filter(
             (tests.c.owner_id==1) &
-            text('options.someoption is null or options.someoption=%s' % false)).
+            text('options.someoption is null or options.someoption={0!s}'.format(false))).
              join('owner_option'))
 
-        result = ["%d %s" % ( t.id,t.category.name ) for t in l]
+        result = ["{0:d} {1!s}".format(t.id, t.category.name ) for t in l]
         eq_(result, ['3 Some Category'])
 
     def test_withoutouterjoin(self):
@@ -233,7 +233,7 @@ class EagerTest(fixtures.MappedTest):
             ((options.c.someoption==None) | (options.c.someoption==False))
                     ).join('owner_option')
 
-        result = ["%d %s" % ( t.id,t.category.name ) for t in l]
+        result = ["{0:d} {1!s}".format(t.id, t.category.name ) for t in l]
         eq_(result, ['3 Some Category'])
 
 

--- a/test/orm/test_bundle.py
+++ b/test/orm/test_bundle.py
@@ -46,8 +46,8 @@ class BundleTest(fixtures.MappedTest, AssertsCompiledSQL):
     def insert_data(cls):
         sess = Session()
         sess.add_all([
-            cls.classes.Data(d1='d%dd1' % i, d2='d%dd2' % i, d3='d%dd3' % i,
-                    others=[cls.classes.Other(o1="d%do%d" % (i, j)) for j in range(5)])
+            cls.classes.Data(d1='d{0:d}d1'.format(i), d2='d{0:d}d2'.format(i), d3='d{0:d}d3'.format(i),
+                    others=[cls.classes.Other(o1="d{0:d}o{1:d}".format(i, j)) for j in range(5)])
             for i in range(10)
         ])
         sess.commit()

--- a/test/orm/test_collection.py
+++ b/test/orm/test_collection.py
@@ -65,7 +65,7 @@ class CollectionsTest(fixtures.ORMTest):
     @classmethod
     def dictable_entity(cls, a=None, b=None, c=None):
         id = cls._entity_id = (cls._entity_id + 1)
-        return cls.Entity(a or str(id), b or 'value %s' % id, c)
+        return cls.Entity(a or str(id), b or 'value {0!s}'.format(id), c)
 
     def _test_adapter(self, typecallable, creator=None, to_set=None):
         if creator is None:
@@ -426,7 +426,7 @@ class CollectionsTest(fixtures.ORMTest):
             def __eq__(self, other):
                 return self.data == other
             def __repr__(self):
-                return 'ListLike(%s)' % repr(self.data)
+                return 'ListLike({0!s})'.format(repr(self.data))
 
         self._test_adapter(ListLike)
         self._test_list(ListLike)
@@ -460,7 +460,7 @@ class CollectionsTest(fixtures.ORMTest):
             def __eq__(self, other):
                 return self.data == other
             def __repr__(self):
-                return 'ListLike(%s)' % repr(self.data)
+                return 'ListLike({0!s})'.format(repr(self.data))
 
         self._test_adapter(ListLike)
         self._test_list(ListLike)
@@ -488,7 +488,7 @@ class CollectionsTest(fixtures.ORMTest):
             def __eq__(self, other):
                 return self.data == other
             def __repr__(self):
-                return 'ListIsh(%s)' % repr(self.data)
+                return 'ListIsh({0!s})'.format(repr(self.data))
 
         self._test_adapter(ListIsh)
         self._test_list(ListIsh)
@@ -1125,7 +1125,7 @@ class CollectionsTest(fixtures.ORMTest):
         # tests #2654
         class MyDict(collections.MappedCollection):
             def __init__(self):
-                super(MyDict, self).__init__(lambda value: "k%d" % value)
+                super(MyDict, self).__init__(lambda value: "k{0:d}".format(value))
 
             @collection.converter
             def _convert(self, dictlike):
@@ -1178,7 +1178,7 @@ class CollectionsTest(fixtures.ORMTest):
             def __eq__(self, other):
                 return self.data == other
             def __repr__(self):
-                return 'DictLike(%s)' % repr(self.data)
+                return 'DictLike({0!s})'.format(repr(self.data))
 
         self._test_adapter(DictLike, self.dictable_entity,
                            to_set=lambda c: set(c.values()))
@@ -1218,7 +1218,7 @@ class CollectionsTest(fixtures.ORMTest):
             def __eq__(self, other):
                 return self.data == other
             def __repr__(self):
-                return 'DictIsh(%s)' % repr(self.data)
+                return 'DictIsh({0!s})'.format(repr(self.data))
 
         self._test_adapter(DictIsh, self.dictable_entity,
                            to_set=lambda c: set(c.values()))
@@ -1926,7 +1926,7 @@ class CustomCollectionsTest(fixtures.MappedTest):
             def __eq__(self, other):
                 return self.data == other
             def __repr__(self):
-                return 'ListLike(%s)' % repr(self.data)
+                return 'ListLike({0!s})'.format(repr(self.data))
 
         self._test_list(ListLike)
 

--- a/test/orm/test_composites.py
+++ b/test/orm/test_composites.py
@@ -437,7 +437,7 @@ class DefaultsTest(fixtures.MappedTest):
             def __ne__(self, other):
                 return not self.__eq__(other)
             def __repr__(self):
-                return "FBComposite(%r, %r, %r, %r)" % (
+                return "FBComposite({0!r}, {1!r}, {2!r}, {3!r})".format(
                     self.goofy_x1, self.x2, self.x3, self.x4
                 )
         mapper(Foobar, foobars, properties=dict(

--- a/test/orm/test_evaluator.py
+++ b/test/orm/test_evaluator.py
@@ -17,7 +17,7 @@ def eval_eq(clause, testcases=None):
 
     def testeval(obj=None, expected_result=None):
         assert evaluator(obj) == expected_result, \
-            "%s != %r for %s with %r" % (
+            "{0!s} != {1!r} for {2!s} with {3!r}".format(
                 evaluator(obj), expected_result, clause, obj)
     if testcases:
         for an_obj, result in testcases:

--- a/test/orm/test_events.py
+++ b/test/orm/test_events.py
@@ -1541,11 +1541,11 @@ class SessionEventsTest(_RemoveListeners, _fixtures.FixtureTest):
         def before_flush(session, flush_context, objects):
             for obj in list(session.new) + list(session.dirty):
                 if isinstance(obj, User):
-                    session.add(User(name='another %s' % obj.name))
+                    session.add(User(name='another {0!s}'.format(obj.name)))
             for obj in list(session.deleted):
                 if isinstance(obj, User):
                     x = session.query(User).filter(
-                        User.name == 'another %s' % obj.name).one()
+                        User.name == 'another {0!s}'.format(obj.name)).one()
                     session.delete(x)
 
         sess = Session()
@@ -2341,13 +2341,13 @@ class AttributeExtensionTest(fixtures.MappedTest):
         class Ex1(sa.orm.AttributeExtension):
 
             def set(self, state, value, oldvalue, initiator):
-                ext_msg.append("Ex1 %r" % value)
+                ext_msg.append("Ex1 {0!r}".format(value))
                 return "ex1" + value
 
         class Ex2(sa.orm.AttributeExtension):
 
             def set(self, state, value, oldvalue, initiator):
-                ext_msg.append("Ex2 %r" % value)
+                ext_msg.append("Ex2 {0!r}".format(value))
                 return "ex2" + value
 
         class A(fixtures.BasicEntity):

--- a/test/orm/test_instrumentation.py
+++ b/test/orm/test_instrumentation.py
@@ -696,7 +696,7 @@ class MiscTest(fixtures.ORMTest):
 
             session = create_session()
             session.add(b)
-            assert a in session, "base is %s" % base
+            assert a in session, "base is {0!s}".format(base)
 
     def test_compileonattr_rel_backref_b(self):
         m = MetaData()
@@ -728,6 +728,6 @@ class MiscTest(fixtures.ORMTest):
 
             session = create_session()
             session.add(a)
-            assert b in session, 'base: %s' % base
+            assert b in session, 'base: {0!s}'.format(base)
 
 

--- a/test/orm/test_lazy_relations.py
+++ b/test/orm/test_lazy_relations.py
@@ -567,7 +567,7 @@ class GetterStateTest(_fixtures.FixtureTest):
 
             def process_bind_param(self, value, dialect):
                 return ";".join(
-                    "%s=%s" % (k, v)
+                    "{0!s}={1!s}".format(k, v)
                        for k, v in
                        sorted(value.items(), key=lambda key: key[0]))
 

--- a/test/orm/test_mapper.py
+++ b/test/orm/test_mapper.py
@@ -283,7 +283,7 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
                     assert not isinstance(other, basestring)
                     return int(self) < other
 
-        foos = [Foo(id='f%d' % i) for i in range(5)]
+        foos = [Foo(id='f{0:d}'.format(i)) for i in range(5)]
         states = [attributes.instance_state(f) for f in foos]
 
         for s in states[0:3]:
@@ -1902,7 +1902,7 @@ class ORMLoggingTest(_fixtures.FixtureTest):
         s.commit()
 
         for msg in self._current_messages():
-            assert msg.startswith('(User|%%(%d anon)s) ' % id(tb))
+            assert msg.startswith('(User|%({0:d} anon)s) '.format(id(tb)))
 
 
 class OptionsTest(_fixtures.FixtureTest):

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -961,8 +961,8 @@ class OperatorTest(QueryTest, AssertsCompiledSQL):
                 # 'a' < 'b' -or- 'b' > 'a'.
                 compiled = str(py_op(lhs, rhs).compile(
                     dialect=default.DefaultDialect()))
-                fwd_sql = "%s %s %s" % (l_sql, fwd_op, r_sql)
-                rev_sql = "%s %s %s" % (r_sql, rev_op, l_sql)
+                fwd_sql = "{0!s} {1!s} {2!s}".format(l_sql, fwd_op, r_sql)
+                rev_sql = "{0!s} {1!s} {2!s}".format(r_sql, rev_op, l_sql)
 
                 self.assert_(compiled == fwd_sql or compiled == rev_sql,
                              "\n'" + compiled + "'\n does not match\n'" +
@@ -1390,7 +1390,7 @@ class OperatorTest(QueryTest, AssertsCompiledSQL):
             # (User.id, "users.id")
         ):
             c = expr.compile(dialect=default.DefaultDialect())
-            assert str(c) == compare, "%s != %s" % (str(c), compare)
+            assert str(c) == compare, "{0!s} != {1!s}".format(str(c), compare)
 
 
 class ExpressionTest(QueryTest, AssertsCompiledSQL):
@@ -1465,7 +1465,7 @@ class ExpressionTest(QueryTest, AssertsCompiledSQL):
 
         eq_(a1.name, 'foo1')
         eq_(a2.name, 'foo2')
-        eq_(a3.name, '%%(%d anon)s' % id(a3))
+        eq_(a3.name, '%({0:d} anon)s'.format(id(a3)))
 
     def test_labeled_subquery(self):
         User = self.classes.User

--- a/test/orm/test_session.py
+++ b/test/orm/test_session.py
@@ -1223,7 +1223,7 @@ class StrongIdentityMapTest(_fixtures.FixtureTest):
 
         mapper(User, users)
 
-        for o in [User(name='u%s' % x) for x in range(10)]:
+        for o in [User(name='u{0!s}'.format(x)) for x in range(10)]:
             s.add(o)
         # o is still live after this loop...
 
@@ -1729,6 +1729,6 @@ class FlushWarningsTest(fixtures.MappedTest):
         s.add(u1)
         assert_raises_message(
             sa.exc.SAWarning,
-            "Usage of the '%s'" % method,
+            "Usage of the '{0!s}'".format(method),
             s.commit
         )

--- a/test/perf/invalidate_stresstest.py
+++ b/test/perf/invalidate_stresstest.py
@@ -42,7 +42,7 @@ def main():
 
     while True:
         result = list(engine.execute("show processlist"))
-        engine.execute("kill %d" % result[-2][0])
+        engine.execute("kill {0:d}".format(result[-2][0]))
         print "\n\n\n BOOM!!!!! \n\n\n"
         gevent.sleep(5)
         print(engine.pool.status())

--- a/test/perf/orm2010.py
+++ b/test/perf/orm2010.py
@@ -68,23 +68,23 @@ def runit(status, factor=1, query_runs=5):
 
     bosses = [
         Boss(
-            name="Boss %d" % i,
+            name="Boss {0:d}".format(i),
             golf_average=Decimal(random.randint(40, 150))
         )
         for i in range(num_bosses)
     ]
 
     sess.add_all(bosses)
-    status("Added %d boss objects" % num_bosses)
+    status("Added {0:d} boss objects".format(num_bosses))
 
     grunts = [
         Grunt(
-            name="Grunt %d" % i,
+            name="Grunt {0:d}".format(i),
             savings=Decimal(random.randint(5000000, 15000000) / 100)
         )
         for i in range(num_grunts)
     ]
-    status("Added %d grunt objects" % num_grunts)
+    status("Added {0:d} grunt objects".format(num_grunts))
 
     while grunts:
         # this doesn't associate grunts with bosses evenly,
@@ -93,7 +93,7 @@ def runit(status, factor=1, query_runs=5):
         batch_size = 100
         batch_num = (num_grunts - len(grunts)) / batch_size
         boss = sess.query(Boss).\
-                    filter_by(name="Boss %d" % batch_num).\
+                    filter_by(name="Boss {0:d}".format(batch_num)).\
                     first()
         for grunt in grunts[0:batch_size]:
             grunt.employer = boss
@@ -105,7 +105,7 @@ def runit(status, factor=1, query_runs=5):
 
     # do some heavier reading
     for i in range(query_runs):
-        status("Heavy query run #%d" % (i + 1))
+        status("Heavy query run #{0:d}".format((i + 1)))
 
         report = []
 
@@ -137,22 +137,20 @@ def run_with_profile(runsnake=False, dump=False):
 
     counts_by_methname = dict((key[2], stats.stats[key][0]) for key in stats.stats)
 
-    print("SQLA Version: %s" % __version__)
-    print("Total calls %d" % stats.total_calls)
-    print("Total cpu seconds: %.2f" % stats.total_tt)
-    print('Total execute calls: %d' \
-        % counts_by_methname["<method 'execute' of 'sqlite3.Cursor' "
-                             "objects>"])
-    print('Total executemany calls: %d' \
-        % counts_by_methname.get("<method 'executemany' of 'sqlite3.Cursor' "
-                             "objects>", 0))
+    print("SQLA Version: {0!s}".format(__version__))
+    print("Total calls {0:d}".format(stats.total_calls))
+    print("Total cpu seconds: {0:.2f}".format(stats.total_tt))
+    print('Total execute calls: {0:d}'.format(counts_by_methname["<method 'execute' of 'sqlite3.Cursor' "
+                             "objects>"]))
+    print('Total executemany calls: {0:d}'.format(counts_by_methname.get("<method 'executemany' of 'sqlite3.Cursor' "
+                             "objects>", 0)))
 
     if dump:
         stats.sort_stats('time', 'calls')
         stats.print_stats()
 
     if runsnake:
-        os.system("runsnake %s" % filename)
+        os.system("runsnake {0!s}".format(filename))
 
 
 def run_with_time():
@@ -160,10 +158,10 @@ def run_with_time():
     now = time.time()
 
     def status(msg):
-        print("%d - %s" % (time.time() - now, msg))
+        print("{0:d} - {1!s}".format(time.time() - now, msg))
 
     runit(status, 10)
-    print("Total time: %d" % (time.time() - now))
+    print("Total time: {0:d}".format((time.time() - now)))
 
 if __name__ == '__main__':
     import argparse

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -264,13 +264,13 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
             def get_select_precolumns(self, select, **kw):
                 result = ""
                 if select._limit:
-                    result += "FIRST %s " % self.process(
+                    result += "FIRST {0!s} ".format(self.process(
                         literal(
-                            select._limit), **kw)
+                            select._limit), **kw))
                 if select._offset:
-                    result += "SKIP %s " % self.process(
+                    result += "SKIP {0!s} ".format(self.process(
                         literal(
-                            select._offset), **kw)
+                            select._offset), **kw))
                 return result
 
             def limit_clause(self, select, **kw):
@@ -2026,13 +2026,13 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
 
         total_params = 100000
 
-        in_clause = [':in%d' % i for i in range(total_params)]
-        params = dict(('in%d' % i, i) for i in range(total_params))
-        t = text('text clause %s' % ', '.join(in_clause))
+        in_clause = [':in{0:d}'.format(i) for i in range(total_params)]
+        params = dict(('in{0:d}'.format(i), i) for i in range(total_params))
+        t = text('text clause {0!s}'.format(', '.join(in_clause)))
         eq_(len(t.bindparams), total_params)
         c = t.compile()
         pp = c.construct_params(params)
-        eq_(len(set(pp)), total_params, '%s %s' % (len(set(pp)), len(pp)))
+        eq_(len(set(pp)), total_params, '{0!s} {1!s}'.format(len(set(pp)), len(pp)))
         eq_(len(set(pp.values())), total_params)
 
     def test_bind_as_col(self):
@@ -2134,17 +2134,17 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
             eq_(len(expected_results), 5,
                 'Incorrect number of expected results')
             eq_(str(cast(tbl.c.v1, Numeric).compile(dialect=dialect)),
-                'CAST(casttest.v1 AS %s)' % expected_results[0])
+                'CAST(casttest.v1 AS {0!s})'.format(expected_results[0]))
             eq_(str(tbl.c.v1.cast(Numeric).compile(dialect=dialect)),
-                'CAST(casttest.v1 AS %s)' % expected_results[0])
+                'CAST(casttest.v1 AS {0!s})'.format(expected_results[0]))
             eq_(str(cast(tbl.c.v1, Numeric(12, 9)).compile(dialect=dialect)),
-                'CAST(casttest.v1 AS %s)' % expected_results[1])
+                'CAST(casttest.v1 AS {0!s})'.format(expected_results[1]))
             eq_(str(cast(tbl.c.ts, Date).compile(dialect=dialect)),
-                'CAST(casttest.ts AS %s)' % expected_results[2])
+                'CAST(casttest.ts AS {0!s})'.format(expected_results[2]))
             eq_(str(cast(1234, Text).compile(dialect=dialect)),
-                'CAST(%s AS %s)' % (literal, expected_results[3]))
+                'CAST({0!s} AS {1!s})'.format(literal, expected_results[3]))
             eq_(str(cast('test', String(20)).compile(dialect=dialect)),
-                'CAST(%s AS %s)' % (literal, expected_results[4]))
+                'CAST({0!s} AS {1!s})'.format(literal, expected_results[4]))
 
             # fixme: shoving all of this dialect-specific stuff in one test
             # is now officially completely ridiculous AND non-obviously omits
@@ -2505,25 +2505,21 @@ class SelectTest(fixtures.TestBase, AssertsCompiledSQL):
 
             if lbl:
                 self.assert_compile(
-                    s1, "SELECT %s AS %s FROM mytable" %
-                    (expr, lbl))
+                    s1, "SELECT {0!s} AS {1!s} FROM mytable".format(expr, lbl))
             else:
-                self.assert_compile(s1, "SELECT %s FROM mytable" % (expr,))
+                self.assert_compile(s1, "SELECT {0!s} FROM mytable".format(expr))
 
             s1 = select([s1])
             if lbl:
                 self.assert_compile(
-                    s1, "SELECT %s FROM (SELECT %s AS %s FROM mytable)" %
-                    (lbl, expr, lbl))
+                    s1, "SELECT {0!s} FROM (SELECT {1!s} AS {2!s} FROM mytable)".format(lbl, expr, lbl))
             elif col.table is not None:
                 # sqlite rule labels subquery columns
                 self.assert_compile(
-                    s1, "SELECT %s FROM (SELECT %s AS %s FROM mytable)" %
-                    (key, expr, key))
+                    s1, "SELECT {0!s} FROM (SELECT {1!s} AS {2!s} FROM mytable)".format(key, expr, key))
             else:
                 self.assert_compile(s1,
-                                    "SELECT %s FROM (SELECT %s FROM mytable)" %
-                                    (expr, expr))
+                                    "SELECT {0!s} FROM (SELECT {1!s} FROM mytable)".format(expr, expr))
 
     def test_hints(self):
         s = select([table1.c.myid]).with_hint(table1, "test hint %(name)s")
@@ -3848,7 +3844,7 @@ class ResultMapTest(fixtures.TestBase):
                 'a': ('a', (t.c.a, 'a', 'a'), t.c.a.type),
                 'bar': ('bar', (l1, 'bar'), l1.type),
                 'anon_1': (
-                    '%%(%d anon)s' % id(tc),
+                    '%({0:d} anon)s'.format(id(tc)),
                     (tc_anon_label, 'anon_1', tc), tc.type),
             },
         )

--- a/test/sql/test_ddlemit.py
+++ b/test/sql/test_ddlemit.py
@@ -38,7 +38,7 @@ class EmitDDLTest(fixtures.TestBase):
         m = MetaData()
 
         return (m, ) + tuple(
-            Table('t%d' % i, m, Column('x', Integer))
+            Table('t{0:d}'.format(i), m, Column('x', Integer))
             for i in range(1, 6)
         )
 
@@ -254,11 +254,10 @@ class EmitDDLTest(fixtures.TestBase):
         for call_ in generator.connection.execute.mock_calls:
             c = call_[1][0]
             assert isinstance(c, ddl_cls)
-            assert c.element in elements, "element %r was not expected"\
-                % c.element
+            assert c.element in elements, "element {0!r} was not expected".format(c.element)
             elements.remove(c.element)
             if getattr(c, 'include_foreign_key_constraints', None) is not None:
                 elements[:] = [
                     e for e in elements
                     if e not in set(c.include_foreign_key_constraints)]
-        assert not elements, "elements remain in list: %r" % elements
+        assert not elements, "elements remain in list: {0!r}".format(elements)

--- a/test/sql/test_defaults.py
+++ b/test/sql/test_defaults.py
@@ -1278,7 +1278,7 @@ class SpecialTypePKTest(fixtures.TestBase):
             def process_result_value(self, value, dialect):
                 if value is None:
                     return None
-                return "INT_%d" % value
+                return "INT_{0:d}".format(value)
 
         cls.MyInteger = MyInteger
 

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -226,7 +226,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
                  sqltypes.DateTime)
             ]:
                 assert isinstance(fn(*args).type, type_), \
-                    "%s / %r != %s" % (fn(), fn(*args).type, type_)
+                    "{0!s} / {1!r} != {2!s}".format(fn(), fn(*args).type, type_)
 
         assert isinstance(func.concat("foo", "bar").type, sqltypes.String)
 

--- a/test/sql/test_generative.py
+++ b/test/sql/test_generative.py
@@ -45,7 +45,7 @@ class TraversalTest(fixtures.TestBase, AssertsExecutionResults):
                 return other.expr != self.expr
 
             def __str__(self):
-                return "A(%s)" % repr(self.expr)
+                return "A({0!s})".format(repr(self.expr))
 
         class B(ClauseElement):
             __visit_name__ = 'b'
@@ -82,7 +82,7 @@ class TraversalTest(fixtures.TestBase, AssertsExecutionResults):
                 return self.items
 
             def __str__(self):
-                return "B(%s)" % repr([str(i) for i in self.items])
+                return "B({0!s})".format(repr([str(i) for i in self.items]))
 
     def test_test_classes(self):
         a1 = A("expr1")

--- a/test/sql/test_metadata.py
+++ b/test/sql/test_metadata.py
@@ -83,7 +83,7 @@ class MetaDataTest(fixtures.TestBase, ComparesTables):
         msgs = []
 
         def write(c, t):
-            msgs.append("attach %s.%s" % (t.name, c.name))
+            msgs.append("attach {0!s}.{1!s}".format(t.name, c.name))
         c1 = Column('foo', String())
         m = MetaData()
         for i in range(3):
@@ -92,7 +92,7 @@ class MetaDataTest(fixtures.TestBase, ComparesTables):
             # that listeners will be re-established from the
             # natural construction of things.
             cx._on_table_attach(write)
-            Table('foo%d' % i, m, cx)
+            Table('foo{0:d}'.format(i), m, cx)
         eq_(msgs, ['attach foo0.foo', 'attach foo1.foo', 'attach foo2.foo'])
 
     def test_schema_collection_add(self):
@@ -456,15 +456,15 @@ class MetaDataTest(fixtures.TestBase, ComparesTables):
             if quote_schema is not None:
                 kw['quote_schema'] = quote_schema
             t = Table(name, metadata, **kw)
-            eq_(t.schema, exp_schema, "test %d, table schema" % i)
+            eq_(t.schema, exp_schema, "test {0:d}, table schema".format(i))
             eq_(t.schema.quote if t.schema is not None else None,
                 exp_quote_schema,
-                "test %d, table quote_schema" % i)
+                "test {0:d}, table quote_schema".format(i))
             seq = Sequence(name, metadata=metadata, **kw)
-            eq_(seq.schema, exp_schema, "test %d, seq schema" % i)
+            eq_(seq.schema, exp_schema, "test {0:d}, seq schema".format(i))
             eq_(seq.schema.quote if seq.schema is not None else None,
                 exp_quote_schema,
-                "test %d, seq quote_schema" % i)
+                "test {0:d}, seq quote_schema".format(i))
 
     def test_manual_dependencies(self):
         meta = MetaData()
@@ -3134,7 +3134,7 @@ class ColumnDefinitionTest(AssertsCompiledSQL, fixtures.TestBase):
             if "special" not in column.info:
                 return compiler.visit_create_column(element, **kw)
 
-            text = "%s SPECIAL DIRECTIVE %s" % (
+            text = "{0!s} SPECIAL DIRECTIVE {1!s}".format(
                 column.name,
                 compiler.type_compiler.process(column.type)
             )
@@ -3351,11 +3351,11 @@ class CatchAllEventsTest(fixtures.RemovesEvents, fixtures.TestBase):
         canary = []
 
         def before_attach(obj, parent):
-            canary.append("%s->%s" % (obj.__class__.__name__,
+            canary.append("{0!s}->{1!s}".format(obj.__class__.__name__,
                                       parent.__class__.__name__))
 
         def after_attach(obj, parent):
-            canary.append("%s->%s" % (obj.__class__.__name__, parent))
+            canary.append("{0!s}->{1!s}".format(obj.__class__.__name__, parent))
 
         self.event_listen(
             schema.SchemaItem,
@@ -3393,12 +3393,12 @@ class CatchAllEventsTest(fixtures.RemovesEvents, fixtures.TestBase):
 
         def evt(target):
             def before_attach(obj, parent):
-                canary.append("%s->%s" % (target.__name__,
+                canary.append("{0!s}->{1!s}".format(target.__name__,
                                           parent.__class__.__name__))
 
             def after_attach(obj, parent):
                 assert hasattr(obj, 'name')  # so we can change it
-                canary.append("%s->%s" % (target.__name__, parent))
+                canary.append("{0!s}->{1!s}".format(target.__name__, parent))
             self.event_listen(target, "before_parent_attach", before_attach)
             self.event_listen(target, "after_parent_attach", after_attach)
 
@@ -3480,7 +3480,7 @@ class DialectKWArgTest(fixtures.TestBase):
             elif dialect_name == "nonparticipating":
                 return NonParticipatingDialect
             else:
-                raise exc.NoSuchModuleError("no dialect %r" % dialect_name)
+                raise exc.NoSuchModuleError("no dialect {0!r}".format(dialect_name))
         with mock.patch("sqlalchemy.dialects.registry.load", load):
             yield
 
@@ -3585,7 +3585,7 @@ class DialectKWArgTest(fixtures.TestBase):
     def test_runs_safekwarg(self):
 
         with mock.patch("sqlalchemy.util.safe_kwarg",
-                        lambda arg: "goofy_%s" % arg):
+                        lambda arg: "goofy_{0!s}".format(arg)):
             with self._fixture():
                 idx = Index('a', 'b')
                 idx.kwargs[util.u('participating_x')] = 7
@@ -3987,7 +3987,7 @@ class NamingConventionTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_custom(self):
         def key_hash(const, table):
-            return "HASH_%s" % table.name
+            return "HASH_{0!s}".format(table.name)
 
         u1 = self._fixture(naming_convention={
             "fk": "fk_%(table_name)s_%(key_hash)s",

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -786,13 +786,13 @@ class ArrayIndexOpTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
         class MyCompiler(compiler.SQLCompiler):
             def visit_slice(self, element, **kw):
-                return "%s:%s" % (
+                return "{0!s}:{1!s}".format(
                     self.process(element.start, **kw),
-                    self.process(element.stop, **kw),
+                    self.process(element.stop, **kw)
                 )
 
             def visit_getitem_binary(self, binary, operator, **kw):
-                return "%s[%s]" % (
+                return "{0!s}[{1!s}]".format(
                     self.process(binary.left, **kw),
                     self.process(binary.right, **kw)
                 )
@@ -1863,8 +1863,8 @@ class ComparisonOperatorTest(fixtures.TestBase, testing.AssertsCompiledSQL):
             # the compiled clause should match either (e.g.):
             # 'a' < 'b' -or- 'b' > 'a'.
             compiled = str(py_op(lhs, rhs))
-            fwd_sql = "%s %s %s" % (l_sql, fwd_op, r_sql)
-            rev_sql = "%s %s %s" % (r_sql, rev_op, l_sql)
+            fwd_sql = "{0!s} {1!s} {2!s}".format(l_sql, fwd_op, r_sql)
+            rev_sql = "{0!s} {1!s} {2!s}".format(r_sql, rev_op, l_sql)
 
             self.assert_(compiled == fwd_sql or compiled == rev_sql,
                          "\n'" + compiled + "'\n does not match\n'" +
@@ -1960,7 +1960,7 @@ class NegationTest(fixtures.TestBase, testing.AssertsCompiledSQL):
                 (self.table1.c.myid, "mytable.myid"),
                 (literal("foo"), ":param_1"),
             ):
-                self.assert_compile(py_op(expr), "%s%s" % (op, expected))
+                self.assert_compile(py_op(expr), "{0!s}{1!s}".format(op, expected))
 
     def test_negate_operators_2(self):
         self.assert_compile(

--- a/test/sql/test_query.py
+++ b/test/sql/test_query.py
@@ -229,8 +229,8 @@ class QueryTest(fixtures.TestBase):
 
         def a_eq(got, wanted):
             if got != wanted:
-                print("Wanted %s" % wanted)
-                print("Received %s" % got)
+                print("Wanted {0!s}".format(wanted))
+                print("Received {0!s}".format(got))
             self.assert_(got == wanted, got)
 
         a_eq(prep('select foo'), 'select foo')
@@ -266,7 +266,7 @@ class QueryTest(fixtures.TestBase):
                 return int(value[4:])
 
             def process_result_value(self, value, dialect):
-                return "INT_%d" % value
+                return "INT_{0:d}".format(value)
 
         eq_(
             testing.db.scalar(select([cast("INT_5", type_=MyInteger)])),

--- a/test/sql/test_quote.py
+++ b/test/sql/test_quote.py
@@ -70,12 +70,12 @@ class QuoteExecTest(fixtures.TestBase):
             testing.db.execute("CREATE TABLE TAB1 (id INTEGER)")
         else:
             testing.db.execute("CREATE TABLE tab1 (id INTEGER)")
-        testing.db.execute('CREATE TABLE %s (id INTEGER)' %
-                           preparer.quote_identifier("tab2"))
-        testing.db.execute('CREATE TABLE %s (id INTEGER)' %
-                           preparer.quote_identifier("TAB3"))
-        testing.db.execute('CREATE TABLE %s (id INTEGER)' %
-                           preparer.quote_identifier("TAB4"))
+        testing.db.execute('CREATE TABLE {0!s} (id INTEGER)'.format(
+                           preparer.quote_identifier("tab2")))
+        testing.db.execute('CREATE TABLE {0!s} (id INTEGER)'.format(
+                           preparer.quote_identifier("TAB3")))
+        testing.db.execute('CREATE TABLE {0!s} (id INTEGER)'.format(
+                           preparer.quote_identifier("TAB4")))
 
         t1 = Table('tab1', self.metadata,
                    Column('id', Integer, primary_key=True),
@@ -686,8 +686,8 @@ class PreparerTest(fixtures.TestBase):
 
         def a_eq(have, want):
             if have != want:
-                print("Wanted %s" % want)
-                print("Received %s" % have)
+                print("Wanted {0!s}".format(want))
+                print("Received {0!s}".format(have))
             self.assert_(have == want)
 
         a_eq(unformat('foo'), ['foo'])
@@ -718,8 +718,8 @@ class PreparerTest(fixtures.TestBase):
 
         def a_eq(have, want):
             if have != want:
-                print("Wanted %s" % want)
-                print("Received %s" % have)
+                print("Wanted {0!s}".format(want))
+                print("Received {0!s}".format(have))
             self.assert_(have == want)
 
         a_eq(unformat('foo'), ['foo'])

--- a/test/sql/test_resultset.py
+++ b/test/sql/test_resultset.py
@@ -1147,12 +1147,12 @@ class KeyTargetingTest(fixtures.TablesTest):
 
         if testing.requires.schemas.enabled:
             cls.tables[
-                '%s.wschema' % testing.config.test_schema].insert().execute(
+                '{0!s}.wschema'.format(testing.config.test_schema)].insert().execute(
                 dict(b="a1", q="c1"))
 
     @testing.requires.schemas
     def test_keyed_accessor_wschema(self):
-        keyed1 = self.tables['%s.wschema' % testing.config.test_schema]
+        keyed1 = self.tables['{0!s}.wschema'.format(testing.config.test_schema)]
         row = testing.db.execute(keyed1.select()).first()
 
         eq_(row.b, "a1")
@@ -1534,7 +1534,7 @@ class AlternateResultProxyTest(fixtures.TablesTest):
     @classmethod
     def insert_data(cls):
         cls.engine.execute(cls.tables.test.insert(), [
-            {'x': i, 'y': "t_%d" % i} for i in range(1, 12)
+            {'x': i, 'y': "t_{0:d}".format(i)} for i in range(1, 12)
         ])
 
     @contextmanager
@@ -1557,13 +1557,13 @@ class AlternateResultProxyTest(fixtures.TablesTest):
             assert isinstance(r, cls)
             for i in range(5):
                 rows.append(r.fetchone())
-            eq_(rows, [(i, "t_%d" % i) for i in range(1, 6)])
+            eq_(rows, [(i, "t_{0:d}".format(i)) for i in range(1, 6)])
 
             rows = r.fetchmany(3)
-            eq_(rows, [(i, "t_%d" % i) for i in range(6, 9)])
+            eq_(rows, [(i, "t_{0:d}".format(i)) for i in range(6, 9)])
 
             rows = r.fetchall()
-            eq_(rows, [(i, "t_%d" % i) for i in range(9, 12)])
+            eq_(rows, [(i, "t_{0:d}".format(i)) for i in range(9, 12)])
 
             r = self.engine.execute(select([self.table]))
             rows = r.fetchmany(None)
@@ -1577,7 +1577,7 @@ class AlternateResultProxyTest(fixtures.TablesTest):
 
             r = self.engine.execute(select([self.table]).limit(5))
             rows = r.fetchmany(6)
-            eq_(rows, [(i, "t_%d" % i) for i in range(1, 6)])
+            eq_(rows, [(i, "t_{0:d}".format(i)) for i in range(1, 6)])
 
             # result keeps going just fine with blank results...
             eq_(r.fetchmany(2), [])
@@ -1678,7 +1678,7 @@ class AlternateResultProxyTest(fixtures.TablesTest):
         with self._proxy_fixture(_result.BufferedRowResultProxy):
             with self.engine.connect() as conn:
                 conn.execute(self.table.insert(), [
-                    {'x': i, 'y': "t_%d" % i} for i in range(15, 1200)
+                    {'x': i, 'y': "t_{0:d}".format(i)} for i in range(15, 1200)
                 ])
                 result = conn.execute(self.table.select())
                 checks = {
@@ -1697,7 +1697,7 @@ class AlternateResultProxyTest(fixtures.TablesTest):
         with self._proxy_fixture(_result.BufferedRowResultProxy):
             with self.engine.connect() as conn:
                 conn.execute(self.table.insert(), [
-                    {'x': i, 'y': "t_%d" % i} for i in range(15, 1200)
+                    {'x': i, 'y': "t_{0:d}".format(i)} for i in range(15, 1200)
                 ])
                 result = conn.execution_options(max_row_buffer=27).execute(
                     self.table.select()

--- a/test/sql/test_rowcount.py
+++ b/test/sql/test_rowcount.py
@@ -56,14 +56,14 @@ class FoundRowsTest(fixtures.TestBase, AssertsExecutionResults):
         # WHERE matches 3, 3 rows changed
         department = employees_table.c.department
         r = employees_table.update(department == 'C').execute(department='Z')
-        print("expecting 3, dialect reports %s" % r.rowcount)
+        print("expecting 3, dialect reports {0!s}".format(r.rowcount))
         assert r.rowcount == 3
 
     def test_update_rowcount2(self):
         # WHERE matches 3, 0 rows changed
         department = employees_table.c.department
         r = employees_table.update(department == 'C').execute(department='C')
-        print("expecting 3, dialect reports %s" % r.rowcount)
+        print("expecting 3, dialect reports {0!s}".format(r.rowcount))
         assert r.rowcount == 3
 
     def test_raw_sql_rowcount(self):
@@ -86,5 +86,5 @@ class FoundRowsTest(fixtures.TestBase, AssertsExecutionResults):
         # WHERE matches 3, 3 rows deleted
         department = employees_table.c.department
         r = employees_table.delete(department == 'C').execute()
-        print("expecting 3, dialect reports %s" % r.rowcount)
+        print("expecting 3, dialect reports {0!s}".format(r.rowcount))
         assert r.rowcount == 3

--- a/test/sql/test_text.py
+++ b/test/sql/test_text.py
@@ -550,15 +550,15 @@ class OrderByLabelResolutionTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def _test_warning(self, stmt, offending_clause, expected):
         with expect_warnings(
-                "Can't resolve label reference %r;" % offending_clause):
+                "Can't resolve label reference {0!r};".format(offending_clause)):
             self.assert_compile(
                 stmt,
                 expected
             )
         assert_raises_message(
             exc.SAWarning,
-            "Can't resolve label reference %r; converting to text" %
-            offending_clause,
+            "Can't resolve label reference {0!r}; converting to text".format(
+            offending_clause),
             stmt.compile
         )
 

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -17,7 +17,7 @@ from sqlalchemy import inspection
 from sqlalchemy import exc, types, util, dialects
 from sqlalchemy.util import OrderedDict
 for name in dialects.__all__:
-    __import__("sqlalchemy.dialects.%s" % name)
+    __import__("sqlalchemy.dialects.{0!s}".format(name))
 from sqlalchemy.sql import operators, column, table, null
 from sqlalchemy.schema import CheckConstraint, AddConstraint
 from sqlalchemy.engine import default
@@ -110,12 +110,10 @@ class AdaptTest(fixtures.TestBase):
                     continue
 
                 assert compiled in expected, \
-                    "%r matches none of %r for dialect %s" % \
-                    (compiled, expected, dialect.name)
+                    "{0!r} matches none of {1!r} for dialect {2!s}".format(compiled, expected, dialect.name)
 
                 assert str(types.to_instance(type_)) in expected, \
-                    "default str() of type %r not expected, %r" % \
-                    (type_, expected)
+                    "default str() of type {0!r} not expected, {1!r}".format(type_, expected)
 
     @testing.uses_deprecated()
     def test_adapt_method(self):
@@ -241,7 +239,7 @@ class TypeAffinityTest(fixtures.TestBase):
             (PickleType(), LargeBinary(), True),
             (PickleType(), PickleType(), True),
         ]:
-            eq_(t1._compare_type_affinity(t2), comp, "%s %s" % (t1, t2))
+            eq_(t1._compare_type_affinity(t2), comp, "{0!s} {1!s}".format(t1, t2))
 
     def test_decorator_doesnt_cache(self):
         from sqlalchemy.dialects import postgresql
@@ -326,7 +324,7 @@ class UserDefinedTest(fixtures.TablesTest, AssertsCompiledSQL):
             impl = String
 
             def process_literal_param(self, value, dialect):
-                return "HI->%s<-THERE" % value
+                return "HI->{0!s}<-THERE".format(value)
 
         self.assert_compile(
             select([literal("test", MyType)]),
@@ -338,7 +336,7 @@ class UserDefinedTest(fixtures.TablesTest, AssertsCompiledSQL):
     def test_kw_colspec(self):
         class MyType(types.UserDefinedType):
             def get_col_spec(self, **kw):
-                return "FOOB %s" % kw['type_expression'].name
+                return "FOOB {0!s}".format(kw['type_expression'].name)
 
         class MyOtherType(types.UserDefinedType):
             def get_col_spec(self):
@@ -360,7 +358,7 @@ class UserDefinedTest(fixtures.TablesTest, AssertsCompiledSQL):
             impl = String
 
             def process_bind_param(self, value, dialect):
-                return "HI->%s<-THERE" % value
+                return "HI->{0!s}<-THERE".format(value)
 
         self.assert_compile(
             select([literal("test", MyType)]),
@@ -2172,7 +2170,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
 
             # not affected
             def visit_INTEGER(self, type_, **kw):
-                return "MYINTEGER %s" % kw['type_expression'].name
+                return "MYINTEGER {0!s}".format(kw['type_expression'].name)
 
         dialect = default.DefaultDialect()
         dialect.type_compiler = SomeTypeCompiler(dialect)
@@ -2196,7 +2194,7 @@ class TestKWArgPassThru(AssertsCompiledSQL, fixtures.TestBase):
 
         class MyType(types.UserDefinedType):
             def get_col_spec(self, **kw):
-                return "FOOB %s" % kw['type_expression'].name
+                return "FOOB {0!s}".format(kw['type_expression'].name)
 
         m = MetaData()
         t = Table('t', m, Column('bar', MyType))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
