### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/pyodbc.py
+++ b/lib/sqlalchemy/dialects/mysql/pyodbc.py
@@ -59,7 +59,7 @@ class MySQLDialect_pyodbc(PyODBCConnector, MySQLDialect):
         # If it's decided that issuing that sort of SQL leaves you SOL, then
         # this can prefer the driver value.
         rs = connection.execute("SHOW VARIABLES LIKE 'character_set%%'")
-        opts = dict([(row[0], row[1]) for row in self._compat_fetchall(rs)])
+        opts = {row[0]: row[1] for row in self._compat_fetchall(rs)}
         for key in ('character_set_connection', 'character_set'):
             if opts.get(key, None):
                 return opts[key]

--- a/lib/sqlalchemy/engine/result.py
+++ b/lib/sqlalchemy/engine/result.py
@@ -237,10 +237,8 @@ class ResultMetaData(object):
         self._processors = [elem[3] for elem in raw]
 
         # keymap by primary string...
-        by_key = dict([
-            (elem[2], (elem[3], elem[4], elem[0]))
-            for elem in raw
-        ])
+        by_key = {elem[2]: (elem[3], elem[4], elem[0])
+            for elem in raw}
 
         # for compiled SQL constructs, copy additional lookup keys into
         # the key lookup map, such as Column objects, labels,

--- a/lib/sqlalchemy/ext/baked.py
+++ b/lib/sqlalchemy/ext/baked.py
@@ -363,10 +363,8 @@ class Result(object):
 
         bq = bq.with_criteria(setup, tuple(elem is None for elem in ident))
 
-        params = dict([
-            (_get_params[primary_key].key, id_val)
-            for id_val, primary_key in zip(ident, mapper.primary_key)
-        ])
+        params = {_get_params[primary_key].key: id_val
+            for id_val, primary_key in zip(ident, mapper.primary_key)}
 
         result = list(bq.for_session(self.session).params(**params))
         l = len(result)

--- a/lib/sqlalchemy/orm/loading.py
+++ b/lib/sqlalchemy/orm/loading.py
@@ -196,10 +196,8 @@ def load_on_ident(query, key,
         _get_clause = q._adapt_clause(_get_clause, True, False)
         q._criterion = _get_clause
 
-        params = dict([
-            (_get_params[primary_key].key, id_val)
-            for id_val, primary_key in zip(ident, mapper.primary_key)
-        ])
+        params = {_get_params[primary_key].key: id_val
+            for id_val, primary_key in zip(ident, mapper.primary_key)}
 
         q._params = params
 

--- a/lib/sqlalchemy/sql/compiler.py
+++ b/lib/sqlalchemy/sql/compiler.py
@@ -1732,15 +1732,13 @@ class SQLCompiler(Compiled):
             return text
 
     def _setup_select_hints(self, select):
-        byfrom = dict([
-            (from_, hinttext % {
+        byfrom = {from_: hinttext % {
                 'name': from_._compiler_dispatch(
                     self, ashint=True)
-            })
+            }
             for (from_, dialect), hinttext in
             select._hints.items()
-            if dialect in ('*', self.dialect.name)
-        ])
+            if dialect in ('*', self.dialect.name)}
         hint_text = self.get_select_hint_text(byfrom)
         return hint_text, byfrom
 
@@ -1912,12 +1910,10 @@ class SQLCompiler(Compiled):
         )
 
     def _setup_crud_hints(self, stmt, table_text):
-        dialect_hints = dict([
-            (table, hint_text)
+        dialect_hints = {table: hint_text
             for (table, dialect), hint_text in
             stmt._hints.items()
-            if dialect in ('*', self.dialect.name)
-        ])
+            if dialect in ('*', self.dialect.name)}
         if stmt.table in dialect_hints:
             table_text = self.format_from_hint_text(
                 table_text,

--- a/lib/sqlalchemy/testing/schema.py
+++ b/lib/sqlalchemy/testing/schema.py
@@ -17,8 +17,8 @@ table_options = {}
 def Table(*args, **kw):
     """A schema.Table wrapper/hook for dialect-specific tweaks."""
 
-    test_opts = dict([(k, kw.pop(k)) for k in list(kw)
-                      if k.startswith('test_')])
+    test_opts = {k: kw.pop(k) for k in list(kw)
+                      if k.startswith('test_')}
 
     kw.update(table_options)
 
@@ -64,8 +64,8 @@ def Table(*args, **kw):
 def Column(*args, **kw):
     """A schema.Column wrapper/hook for dialect-specific tweaks."""
 
-    test_opts = dict([(k, kw.pop(k)) for k in list(kw)
-                      if k.startswith('test_')])
+    test_opts = {k: kw.pop(k) for k in list(kw)
+                      if k.startswith('test_')}
 
     if not config.requirements.foreign_key_ddl.enabled_for_config(config):
         args = [arg for arg in args if not isinstance(arg, schema.ForeignKey)]

--- a/test/dialect/test_oracle.py
+++ b/test/dialect/test_oracle.py
@@ -2050,9 +2050,9 @@ class RoundTripIndexTest(fixtures.TestBase):
 
         # make a dictionary of the reflected objects:
 
-        reflected = dict([(obj_definition(i), i) for i in
+        reflected = {obj_definition(i): i for i in
                          reflectedtable.indexes
-                         | reflectedtable.constraints])
+                         | reflectedtable.constraints}
 
         # assert we got primary key constraint and its name, Error
         # if not in dict

--- a/test/orm/test_collection.py
+++ b/test/orm/test_collection.py
@@ -984,14 +984,14 @@ class CollectionsTest(fixtures.ORMTest):
 
         if hasattr(direct, 'update'):
             e = creator()
-            d = dict([(ee.a, ee) for ee in [e, creator(), creator()]])
+            d = {ee.a: ee for ee in [e, creator(), creator()]}
             addall(e, creator())
 
             direct.update(d)
             control.update(d)
             assert_eq()
 
-            kw = dict([(ee.a, ee) for ee in [e, creator()]])
+            kw = {ee.a: ee for ee in [e, creator()]}
             direct.update(**kw)
             control.update(**kw)
             assert_eq()

--- a/test/orm/test_unitofwork.py
+++ b/test/orm/test_unitofwork.py
@@ -1872,7 +1872,7 @@ class ManyToManyTest(_fixtures.FixtureTest):
         session = create_session()
 
         objects = []
-        _keywords = dict([(k.name, k) for k in session.query(Keyword)])
+        _keywords = {k.name: k for k in session.query(Keyword)}
 
         for elem in data[1:]:
             item = Item(description=elem['description'])
@@ -2064,7 +2064,7 @@ class ManyToManyTest(_fixtures.FixtureTest):
         session = create_session()
 
         def fixture():
-            _kw = dict([(k.name, k) for k in session.query(Keyword)])
+            _kw = {k.name: k for k in session.query(Keyword)}
             for n in ('big', 'green', 'purple', 'round', 'huge',
                       'violet', 'yellow', 'blue'):
                 if n not in _kw:

--- a/test/sql/test_insert.py
+++ b/test/sql/test_insert.py
@@ -886,10 +886,9 @@ class MultirowTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
         stmt = table.insert().values(values)
 
         eq_(
-            dict([
-                (k, v.type._type_affinity)
+            {k: v.type._type_affinity
                 for (k, v) in
-                stmt.compile(dialect=postgresql.dialect()).binds.items()]),
+                stmt.compile(dialect=postgresql.dialect()).binds.items()},
             {
                 'foo': Integer, 'data_2': String, 'id_0': Integer,
                 'id_2': Integer, 'foo_1': Integer, 'data_1': String,
@@ -932,10 +931,9 @@ class MultirowTest(_InsertTestBase, fixtures.TablesTest, AssertsCompiledSQL):
 
         stmt = table.insert().values(values)
         eq_(
-            dict([
-                (k, v.type._type_affinity)
+            {k: v.type._type_affinity
                 for (k, v) in
-                stmt.compile(dialect=postgresql.dialect()).binds.items()]),
+                stmt.compile(dialect=postgresql.dialect()).binds.items()},
             {
                 'foo': Integer, 'data_2': String, 'id_0': Integer,
                 'id_2': Integer, 'foo_1': Integer, 'data_1': String,


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
