### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/examples/elementtree/optimized_al.py
+++ b/examples/elementtree/optimized_al.py
@@ -174,7 +174,7 @@ print(document)
 # manually search for a document which contains "/somefile/header/field1:hi"
 print("\nManual search for /somefile/header/field1=='hi':", line)
 d = session.query(Document).join('_nodes', aliased=True).\
-                filter(and_(_Node.parent_id==None, _Node.tag=='somefile')).\
+                filter(and_(_Node.parent_id isNone, _Node.tag=='somefile')).\
                 join('children', aliased=True, from_joinpoint=True).\
                 filter(_Node.tag=='header').\
                 join('children', aliased=True, from_joinpoint=True).\
@@ -191,7 +191,7 @@ def find_document(path, compareto):
     for i, match in enumerate(re.finditer(r'/([\w_]+)(?:\[@([\w_]+)(?:=(.*))?\])?', path)):
         (token, attrname, attrvalue) = match.group(1, 2, 3)
         if first:
-            query = query.join('_nodes', aliased=True).filter(_Node.parent_id==None)
+            query = query.join('_nodes', aliased=True).filter(_Node.parent_id isNone)
             first = False
         else:
             query = query.join('children', aliased=True, from_joinpoint=True)

--- a/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
+++ b/lib/sqlalchemy/dialects/firebird/kinterbasdb.py
@@ -165,7 +165,7 @@ class FBDialect_kinterbasdb(FBDialect):
             raise AssertionError(
                 "Could not determine version from string '%s'" % version)
 
-        if m.group(5) != None:
+        if m.group(5) is not None:
             return tuple([int(x) for x in m.group(6, 7, 4)] + ['firebird'])
         else:
             return tuple([int(x) for x in m.group(1, 2, 3)] + ['interbase'])

--- a/lib/sqlalchemy/ext/associationproxy.py
+++ b/lib/sqlalchemy/ext/associationproxy.py
@@ -441,7 +441,7 @@ class AssociationProxy(interfaces.InspectionAttrInfo):
         if obj is None:
             return or_(
                 self._comparator.has(**{self.value_attr: obj}),
-                self._comparator == None
+                self._comparator is None
             )
         else:
             return self._comparator.has(**{self.value_attr: obj})

--- a/lib/sqlalchemy/orm/relationships.py
+++ b/lib/sqlalchemy/orm/relationships.py
@@ -1273,7 +1273,7 @@ class RelationshipProperty(StrategizedProperty):
                     return sql.and_(*[
                         sql.or_(
                             adapt(x) != state_bindparam(adapt(x), state, y),
-                            adapt(x) == None)
+                            adapt(x) is None)
                         for (x, y) in self.property.local_remote_pairs])
 
             criterion = sql.and_(*[

--- a/lib/sqlalchemy/testing/suite/test_insert.py
+++ b/lib/sqlalchemy/testing/suite/test_insert.py
@@ -135,7 +135,7 @@ class InsertBehaviorTest(fixtures.TablesTest):
 
         r = config.db.execute(
             self.tables.autoinc_pk.select().
-            where(self.tables.autoinc_pk.c.id != None)
+            where(self.tables.autoinc_pk.c.id is not None)
         )
 
         assert len(r.fetchall())

--- a/test/aaa_profiling/test_zoomark.py
+++ b/test/aaa_profiling/test_zoomark.py
@@ -206,11 +206,11 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
             assert len(fulltable(Animal.select(Animal.c.Species.
                                                endswith('pede')))) == 2
             assert len(fulltable(Animal.select(Animal.c.LastEscape
-                                               != None))) == 1
+                                               is not None))) == 1
             assert len(
                 fulltable(
                     Animal.select(
-                        None == Animal.c.LastEscape))) == ITERATIONS + 11
+                        None is Animal.c.LastEscape))) == ITERATIONS + 11
 
             # In operator (containedby)
 
@@ -256,7 +256,7 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
                 fulltable(
                     Zoo.select(
                         and_(
-                            Zoo.c.Founded != None,
+                            Zoo.c.Founded is not None,
                             Zoo.c.Founded < func.current_timestamp(
                                 _type=Date))))) == 3
             assert len(
@@ -313,7 +313,7 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
                 assert lifespan == expected[species]
             expected = ['Montr\xe9al Biod\xf4me', 'Wild Animal Park']
             e = select([Zoo.c.Name],
-                       and_(Zoo.c.Founded != None,
+                       and_(Zoo.c.Founded is not None,
                             Zoo.c.Founded <= func.current_timestamp(),
                             Zoo.c.Founded >= datetime.date(1990,
                                                            1,

--- a/test/aaa_profiling/test_zoomark_orm.py
+++ b/test/aaa_profiling/test_zoomark_orm.py
@@ -206,11 +206,11 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
             assert len(list(self.session.query(Animal).
                             filter(Animal.Species.like('%pede')))) == 2
             assert len(list(self.session.query(Animal).filter(Animal.LastEscape
-                                                         != None))) == 1
+                                                         is not None))) == 1
             assert len(
                 list(
                     self.session.query(Animal).filter(
-                        Animal.LastEscape == None))) == ITERATIONS + 11
+                        Animal.LastEscape is None))) == ITERATIONS + 11
 
             # In operator (containedby)
 
@@ -248,7 +248,7 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
                 list(
                     self.session.query(Zoo).filter(
                         and_(
-                            Zoo.Founded != None,
+                            Zoo.Founded is not None,
                             Zoo.Founded < func.now())))) == 3
             assert len(list(self.session.query(Animal).filter(Animal.LastEscape
                                                          == func.now()))) == 0
@@ -294,7 +294,7 @@ class ZooMarkTest(replay_fixture.ReplayFixtureTest):
                 assert lifespan == expected[species]
             expected = ['Montr\xe9al Biod\xf4me', 'Wild Animal Park']
             e = select([Zoo.c.Name],
-                       and_(Zoo.c.Founded != None,
+                       and_(Zoo.c.Founded is not None,
                             Zoo.c.Founded <= func.current_timestamp(),
                             Zoo.c.Founded >= datetime.date(1990,
                                                            1,

--- a/test/base/test_utils.py
+++ b/test/base/test_utils.py
@@ -1239,8 +1239,8 @@ class IdentitySetTest(fixtures.TestBase):
         eq_(ids.copy(), ids)
 
         # explicit __eq__ and __ne__ tests
-        assert ids != None
-        assert not(ids == None)
+        assert ids is not None
+        assert not(ids is None)
 
         ne_(ids, IdentitySet([o1, o2, o3]))
         ids.clear()

--- a/test/dialect/postgresql/test_types.py
+++ b/test/dialect/postgresql/test_types.py
@@ -1815,7 +1815,7 @@ class HStoreTest(AssertsCompiledSQL, fixtures.TestBase):
 
     def test_where_getitem(self):
         self._test_where(
-            self.hashcol['bar'] == None,
+            self.hashcol['bar'] is None,
             "test_table.hash -> %(hash_1)s IS NULL"
         )
 
@@ -2435,13 +2435,13 @@ class JSONTest(AssertsCompiledSQL, fixtures.TestBase):
     # do anything
     def test_where_getitem(self):
         self._test_where(
-            self.jsoncol['bar'] == None,
+            self.jsoncol['bar'] is None,
             "test_table.test_column -> %(test_column_1)s IS NULL"
         )
 
     def test_where_path(self):
         self._test_where(
-            self.jsoncol[("foo", 1)] == None,
+            self.jsoncol[("foo", 1)] is None,
             "test_table.test_column #> %(test_column_1)s IS NULL"
         )
 
@@ -2480,7 +2480,7 @@ class JSONTest(AssertsCompiledSQL, fixtures.TestBase):
 
     def test_where_getitem_as_text(self):
         self._test_where(
-            self.jsoncol['bar'].astext == None,
+            self.jsoncol['bar'].astext is None,
             "test_table.test_column ->> %(test_column_1)s IS NULL"
         )
 
@@ -2500,7 +2500,7 @@ class JSONTest(AssertsCompiledSQL, fixtures.TestBase):
 
     def test_where_path_as_text(self):
         self._test_where(
-            self.jsoncol[("foo", 1)].astext == None,
+            self.jsoncol[("foo", 1)].astext is None,
             "test_table.test_column #>> %(test_column_1)s IS NULL"
         )
 

--- a/test/ext/test_associationproxy.py
+++ b/test/ext/test_associationproxy.py
@@ -1362,12 +1362,12 @@ class ComparatorTest(fixtures.MappedTest, AssertsCompiledSQL):
         UserKeyword, Keyword = self.classes.UserKeyword, self.classes.Keyword
 
         self._equivalent(
-                self.session.query(Keyword).filter(Keyword.user == None),
+                self.session.query(Keyword).filter(Keyword.user is None),
                 self.session.query(Keyword).
                             filter(
                                 or_(
-                                    Keyword.user_keyword.has(UserKeyword.user == None),
-                                    Keyword.user_keyword == None
+                                    Keyword.user_keyword.has(UserKeyword.user is None),
+                                    Keyword.user_keyword is None
                                 )
 
                             )
@@ -1377,10 +1377,10 @@ class ComparatorTest(fixtures.MappedTest, AssertsCompiledSQL):
         UserKeyword, Keyword = self.classes.UserKeyword, self.classes.Keyword
 
         self._equivalent(
-                self.session.query(Keyword).filter(Keyword.user != None),
+                self.session.query(Keyword).filter(Keyword.user is not None),
                 self.session.query(Keyword).
                             filter(
-                                Keyword.user_keyword.has(UserKeyword.user != None),
+                                Keyword.user_keyword.has(UserKeyword.user is not None),
                             )
                         )
 
@@ -1389,11 +1389,11 @@ class ComparatorTest(fixtures.MappedTest, AssertsCompiledSQL):
         Singular = self.classes.Singular
 
         self._equivalent(
-            self.session.query(User).filter(User.singular_value == None),
+            self.session.query(User).filter(User.singular_value is None),
             self.session.query(User).filter(
                     or_(
-                        User.singular.has(Singular.value == None),
-                        User.singular == None
+                        User.singular.has(Singular.value is None),
+                        User.singular is None
                     )
                 )
         )
@@ -1425,9 +1425,9 @@ class ComparatorTest(fixtures.MappedTest, AssertsCompiledSQL):
         Singular = self.classes.Singular
 
         self._equivalent(
-            self.session.query(User).filter(User.singular_value != None),
+            self.session.query(User).filter(User.singular_value is not None),
             self.session.query(User).filter(
-                        User.singular.has(Singular.value != None),
+                        User.singular.has(Singular.value is not None),
                 )
         )
 

--- a/test/ext/test_hybrid.py
+++ b/test/ext/test_hybrid.py
@@ -20,7 +20,7 @@ class PropertyComparatorTest(fixtures.TestBase, AssertsCompiledSQL):
 
             def __eq__(self, other):
                 if other is None:
-                    return self.expression == None
+                    return self.expression is None
                 else:
                     return func.upper(self.expression) == func.upper(other)
 

--- a/test/orm/inheritance/test_abc_inheritance.py
+++ b/test/orm/inheritance/test_abc_inheritance.py
@@ -82,15 +82,15 @@ def produce_test(parent, child, direction):
                     remote_side = [child_table.c.id]
 
             abcjoin = polymorphic_union(
-                {"a":ta.select(tb.c.id==None, from_obj=[ta.outerjoin(tb, onclause=atob)]),
-                "b":ta.join(tb, onclause=atob).outerjoin(tc, onclause=btoc).select(tc.c.id==None).reduce_columns(),
+                {"a":ta.select(tb.c.id isNone, from_obj=[ta.outerjoin(tb, onclause=atob)]),
+                "b":ta.join(tb, onclause=atob).outerjoin(tc, onclause=btoc).select(tc.c.id isNone).reduce_columns(),
                 "c":tc.join(tb, onclause=btoc).join(ta, onclause=atob)
                 },"type", "abcjoin"
             )
 
             bcjoin = polymorphic_union(
             {
-            "b":ta.join(tb, onclause=atob).outerjoin(tc, onclause=btoc).select(tc.c.id==None).reduce_columns(),
+            "b":ta.join(tb, onclause=atob).outerjoin(tc, onclause=btoc).select(tc.c.id isNone).reduce_columns(),
             "c":tc.join(tb, onclause=btoc).join(ta, onclause=atob)
             },"type", "bcjoin"
             )

--- a/test/orm/inheritance/test_assorted_poly.py
+++ b/test/orm/inheritance/test_assorted_poly.py
@@ -687,7 +687,7 @@ class RelationshipTest7(fixtures.MappedTest):
         car_join = polymorphic_union(
             {
                 'car' : cars.outerjoin(offroad_cars).\
-                        select(offroad_cars.c.car_id == None).reduce_columns(),
+                        select(offroad_cars.c.car_id is None).reduce_columns(),
                 'offroad' : cars.join(offroad_cars)
             }, "type", 'car_join')
 

--- a/test/orm/inheritance/test_relationship.py
+++ b/test/orm/inheritance/test_relationship.py
@@ -229,7 +229,7 @@ class SelfReferentialJ2JTest(fixtures.MappedTest):
 
         eq_(sess.query(Manager)
                 .join(Manager.engineers)
-                .filter(Engineer.reports_to == None).all(),
+                .filter(Engineer.reports_to is None).all(),
             [])
 
         eq_(sess.query(Manager)
@@ -332,7 +332,7 @@ class SelfReferentialJ2JSelfTest(fixtures.MappedTest):
 
         eq_(sess.query(Engineer)
                 .join(Engineer.engineers, aliased=True)
-                .filter(Engineer.reports_to == None).all(),
+                .filter(Engineer.reports_to is None).all(),
             [])
 
         eq_(sess.query(Engineer)
@@ -342,7 +342,7 @@ class SelfReferentialJ2JSelfTest(fixtures.MappedTest):
 
         eq_(sess.query(Engineer)
                 .join(Engineer.engineers, aliased=True)
-                .filter(Engineer.reports_to != None).all(),
+                .filter(Engineer.reports_to is not None).all(),
             [e1, e2])
 
 class M2MFilterTest(fixtures.MappedTest):

--- a/test/orm/inheritance/test_with_poly.py
+++ b/test/orm/inheritance/test_with_poly.py
@@ -56,8 +56,8 @@ class _WithPolymorphicBase(_PolymorphicFixtureBase):
                         pa.Engineer.primary_language==\
                         pa_alias.Engineer.primary_language,
                         and_(
-                            pa.Engineer.primary_language == None,
-                            pa_alias.Engineer.primary_language == None,
+                            pa.Engineer.primary_language is None,
+                            pa_alias.Engineer.primary_language is None,
                             pa.person_id > pa_alias.person_id
                         )
                     )
@@ -84,8 +84,8 @@ class _WithPolymorphicBase(_PolymorphicFixtureBase):
                         pa.Engineer.primary_language==\
                         pa_alias.Engineer.primary_language,
                         and_(
-                            pa.Engineer.primary_language == None,
-                            pa_alias.Engineer.primary_language == None,
+                            pa.Engineer.primary_language is None,
+                            pa_alias.Engineer.primary_language is None,
                             pa.person_id > pa_alias.person_id
                         )
                     )

--- a/test/orm/test_assorted_eager.py
+++ b/test/orm/test_assorted_eager.py
@@ -133,7 +133,7 @@ class EagerTest(fixtures.MappedTest):
         result = sa.select(
             [tests.c.id,categories.c.name],
             sa.and_(tests.c.owner_id == 1,
-                    sa.or_(options.c.someoption==None,
+                    sa.or_(options.c.someoption isNone,
                            options.c.someoption==False)),
             order_by=[tests.c.id],
             from_obj=[tests.join(categories).outerjoin(options, sa.and_(
@@ -154,7 +154,7 @@ class EagerTest(fixtures.MappedTest):
                                                  tests.c.owner_id ==
                                                  options.c.owner_id))).
              filter(sa.and_(tests.c.owner_id==1,
-                            sa.or_(options.c.someoption==None,
+                            sa.or_(options.c.someoption isNone,
                                    options.c.someoption==False))))
 
         result = ["%d %s" % ( t.id,t.category.name ) for t in l]
@@ -181,7 +181,7 @@ class EagerTest(fixtures.MappedTest):
                                                  tests.c.owner_id ==
                                                  options.c.owner_id))).
            filter(sa.and_(tests.c.owner_id == 1,
-                          sa.or_(options.c.someoption==None,
+                          sa.or_(options.c.someoption isNone,
                                  options.c.someoption==False))))
 
         result = ["%d %s" % ( t.id,t.category.name ) for t in l]
@@ -198,7 +198,7 @@ class EagerTest(fixtures.MappedTest):
         q = s.query(Thing).options(sa.orm.joinedload('category'))
         l = q.filter (
             sa.and_(tests.c.owner_id == 1,
-                    sa.or_(options.c.someoption == None,
+                    sa.or_(options.c.someoption is None,
                            options.c.someoption == False))
             ).outerjoin('owner_option')
 
@@ -230,7 +230,7 @@ class EagerTest(fixtures.MappedTest):
         q = s.query(Thing).options(sa.orm.joinedload('category'))
         l = q.filter(
             (tests.c.owner_id==1) &
-            ((options.c.someoption==None) | (options.c.someoption==False))
+            ((options.c.someoption isNone) | (options.c.someoption==False))
                     ).join('owner_option')
 
         result = ["%d %s" % ( t.id,t.category.name ) for t in l]

--- a/test/orm/test_composites.py
+++ b/test/orm/test_composites.py
@@ -182,7 +182,7 @@ class PointTest(fixtures.MappedTest):
                     g.edges[1]
 
         eq_(
-            sess.query(Edge).filter(Edge.start == None).all(),
+            sess.query(Edge).filter(Edge.start is None).all(),
             []
         )
 
@@ -859,7 +859,7 @@ class ComparatorTest(fixtures.MappedTest, testing.AssertsCompiledSQL):
                     e2
 
         eq_(
-            sess.query(Edge).filter(Edge.start==None).all(),
+            sess.query(Edge).filter(Edge.start isNone).all(),
             []
         )
 

--- a/test/orm/test_deprecations.py
+++ b/test/orm/test_deprecations.py
@@ -374,7 +374,7 @@ class QueryAlternativesTest(fixtures.MappedTest):
 
         session = create_session()
 
-        users = session.query(User).filter(User.name != None).all()
+        users = session.query(User).filter(User.name is not None).all()
         assert len(users) == 4
 
     def test_select_by(self):

--- a/test/orm/test_dynamic.py
+++ b/test/orm/test_dynamic.py
@@ -353,7 +353,7 @@ class UOWTest(
             testing.db.scalar(
                 select(
                     [func.count(cast(1, Integer))]).
-                where(addresses.c.user_id != None)),
+                where(addresses.c.user_id is not None)),
             0)
         u1 = sess.query(User).get(u1.id)
         u1.addresses.append(a1)
@@ -361,7 +361,7 @@ class UOWTest(
 
         eq_(
             testing.db.execute(
-                select([addresses]).where(addresses.c.user_id != None)
+                select([addresses]).where(addresses.c.user_id is not None)
             ).fetchall(),
             [(a1.id, u1.id, 'foo')]
         )
@@ -372,7 +372,7 @@ class UOWTest(
             testing.db.scalar(
                 select(
                     [func.count(cast(1, Integer))]).
-                where(addresses.c.user_id != None)),
+                where(addresses.c.user_id is not None)),
             0
         )
 
@@ -380,7 +380,7 @@ class UOWTest(
         sess.flush()
         eq_(
             testing.db.execute(
-                select([addresses]).where(addresses.c.user_id != None)
+                select([addresses]).where(addresses.c.user_id is not None)
             ).fetchall(),
             [(a1.id, u1.id, 'foo')]
         )
@@ -391,7 +391,7 @@ class UOWTest(
         sess.flush()
         eq_(
             testing.db.execute(
-                select([addresses]).where(addresses.c.user_id != None)
+                select([addresses]).where(addresses.c.user_id is not None)
             ).fetchall(),
             [(a2.id, u1.id, 'bar')]
         )
@@ -566,11 +566,11 @@ class UOWTest(
         sess.commit()
         eq_(
             testing.db.scalar(
-                select([func.count('*')]).where(addresses.c.user_id == None)),
+                select([func.count('*')]).where(addresses.c.user_id is None)),
             0)
         eq_(
             testing.db.scalar(
-                select([func.count('*')]).where(addresses.c.user_id != None)),
+                select([func.count('*')]).where(addresses.c.user_id is not None)),
             6)
 
         sess.delete(u)
@@ -581,7 +581,7 @@ class UOWTest(
             eq_(
                 testing.db.scalar(
                     select([func.count('*')]).where(
-                        addresses.c.user_id == None
+                        addresses.c.user_id is None
                     )
                 ),
                 6
@@ -589,7 +589,7 @@ class UOWTest(
             eq_(
                 testing.db.scalar(
                     select([func.count('*')]).where(
-                        addresses.c.user_id != None
+                        addresses.c.user_id is not None
                     )
                 ),
                 0

--- a/test/orm/test_eager_relations.py
+++ b/test/orm/test_eager_relations.py
@@ -1137,7 +1137,7 @@ class EagerTest(_fixtures.FixtureTest, testing.AssertsCompiledSQL):
                 mapper(Address, addresses),
                 primaryjoin=and_(
                     addresses.c.id == orders.c.address_id,
-                    addresses.c.email_address != None
+                    addresses.c.email_address is not None
                 ),
 
                 lazy='joined')

--- a/test/orm/test_evaluator.py
+++ b/test/orm/test_evaluator.py
@@ -73,7 +73,7 @@ class EvaluateTest(fixtures.MappedTest):
     def test_compare_to_none(self):
         User = self.classes.User
 
-        eval_eq(User.name == None, testcases=[
+        eval_eq(User.name is None, testcases=[
             (User(name='foo'), False),
             (User(name=None), True),
         ])

--- a/test/orm/test_generative.py
+++ b/test/orm/test_generative.py
@@ -235,7 +235,7 @@ class RelationshipsTest(_fixtures.FixtureTest):
 
         session = create_session()
         q = (session.query(User).outerjoin('orders', 'addresses').
-             filter(sa.or_(Order.id == None, Address.id == 1)))
+             filter(sa.or_(Order.id is None, Address.id == 1)))
         eq_(set([User(id=7), User(id=8), User(id=10)]),
             set(q.all()))
 
@@ -250,7 +250,7 @@ class RelationshipsTest(_fixtures.FixtureTest):
         session = create_session()
 
         q = (session.query(User).outerjoin('orders', 'addresses').
-             filter(sa.or_(Order.id == None, Address.id == 1)))
+             filter(sa.or_(Order.id is None, Address.id == 1)))
         eq_(q.count(), 4)
 
     def test_from(self):
@@ -266,7 +266,7 @@ class RelationshipsTest(_fixtures.FixtureTest):
         sel = users.outerjoin(orders).outerjoin(
             addresses, orders.c.address_id == addresses.c.id)
         q = (session.query(User).select_from(sel).
-             filter(sa.or_(Order.id == None, Address.id == 1)))
+             filter(sa.or_(Order.id is None, Address.id == 1)))
         eq_(set([User(id=7), User(id=8), User(id=10)]),
             set(q.all()))
 

--- a/test/orm/test_mapper.py
+++ b/test/orm/test_mapper.py
@@ -546,7 +546,7 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
                 cls = self.prop.parent.class_
                 col = getattr(cls, 'name')
                 if other is None:
-                    return col == None
+                    return col is None
                 else:
                     return sa.func.upper(col) == sa.func.upper(other)
 
@@ -1478,7 +1478,7 @@ class MapperTest(_fixtures.FixtureTest, AssertsCompiledSQL):
                 cls = self.prop.parent.class_
                 col = getattr(cls, 'name')
                 if other is None:
-                    return col == None
+                    return col is None
                 else:
                     return sa.func.upper(col) == sa.func.upper(other)
 

--- a/test/orm/test_query.py
+++ b/test/orm/test_query.py
@@ -971,66 +971,66 @@ class OperatorTest(QueryTest, AssertsCompiledSQL):
     def test_o2m_compare_to_null(self):
         User = self.classes.User
 
-        self._test(User.id == None, "users.id IS NULL")
-        self._test(User.id != None, "users.id IS NOT NULL")
-        self._test(~(User.id == None), "users.id IS NOT NULL")
-        self._test(~(User.id != None), "users.id IS NULL")
-        self._test(None == User.id, "users.id IS NULL")
-        self._test(~(None == User.id), "users.id IS NOT NULL")
+        self._test(User.id is None, "users.id IS NULL")
+        self._test(User.id is not None, "users.id IS NOT NULL")
+        self._test(~(User.id is None), "users.id IS NOT NULL")
+        self._test(~(User.id is not None), "users.id IS NULL")
+        self._test(None is User.id, "users.id IS NULL")
+        self._test(~(None is User.id), "users.id IS NOT NULL")
 
     def test_m2o_compare_to_null(self):
         Address = self.classes.Address
-        self._test(Address.user == None, "addresses.user_id IS NULL")
-        self._test(~(Address.user == None), "addresses.user_id IS NOT NULL")
-        self._test(~(Address.user != None), "addresses.user_id IS NULL")
-        self._test(None == Address.user, "addresses.user_id IS NULL")
-        self._test(~(None == Address.user), "addresses.user_id IS NOT NULL")
+        self._test(Address.user is None, "addresses.user_id IS NULL")
+        self._test(~(Address.user is None), "addresses.user_id IS NOT NULL")
+        self._test(~(Address.user is not None), "addresses.user_id IS NULL")
+        self._test(None is Address.user, "addresses.user_id IS NULL")
+        self._test(~(None is Address.user), "addresses.user_id IS NOT NULL")
 
     def test_o2m_compare_to_null_orm_adapt(self):
         User, Address = self.classes.User, self.classes.Address
         self._test_filter_aliases(
-            User.id == None,
+            User.id is None,
             "users_1.id IS NULL", Address, Address.user),
         self._test_filter_aliases(
-            User.id != None,
+            User.id is not None,
             "users_1.id IS NOT NULL", Address, Address.user),
         self._test_filter_aliases(
-            ~(User.id == None),
+            ~(User.id is None),
             "users_1.id IS NOT NULL", Address, Address.user),
         self._test_filter_aliases(
-            ~(User.id != None),
+            ~(User.id is not None),
             "users_1.id IS NULL", Address, Address.user),
 
     def test_m2o_compare_to_null_orm_adapt(self):
         User, Address = self.classes.User, self.classes.Address
         self._test_filter_aliases(
-            Address.user == None,
+            Address.user is None,
             "addresses_1.user_id IS NULL", User, User.addresses),
         self._test_filter_aliases(
-            Address.user != None,
+            Address.user is not None,
             "addresses_1.user_id IS NOT NULL", User, User.addresses),
         self._test_filter_aliases(
-            ~(Address.user == None),
+            ~(Address.user is None),
             "addresses_1.user_id IS NOT NULL", User, User.addresses),
         self._test_filter_aliases(
-            ~(Address.user != None),
+            ~(Address.user is not None),
             "addresses_1.user_id IS NULL", User, User.addresses),
 
     def test_o2m_compare_to_null_aliased(self):
         User = self.classes.User
         u1 = aliased(User)
-        self._test(u1.id == None, "users_1.id IS NULL")
-        self._test(u1.id != None, "users_1.id IS NOT NULL")
-        self._test(~(u1.id == None), "users_1.id IS NOT NULL")
-        self._test(~(u1.id != None), "users_1.id IS NULL")
+        self._test(u1.id is None, "users_1.id IS NULL")
+        self._test(u1.id is not None, "users_1.id IS NOT NULL")
+        self._test(~(u1.id is None), "users_1.id IS NOT NULL")
+        self._test(~(u1.id is not None), "users_1.id IS NULL")
 
     def test_m2o_compare_to_null_aliased(self):
         Address = self.classes.Address
         a1 = aliased(Address)
-        self._test(a1.user == None, "addresses_1.user_id IS NULL")
-        self._test(~(a1.user == None), "addresses_1.user_id IS NOT NULL")
-        self._test(a1.user != None, "addresses_1.user_id IS NOT NULL")
-        self._test(~(a1.user != None), "addresses_1.user_id IS NULL")
+        self._test(a1.user is None, "addresses_1.user_id IS NULL")
+        self._test(~(a1.user is None), "addresses_1.user_id IS NOT NULL")
+        self._test(a1.user is not None, "addresses_1.user_id IS NOT NULL")
+        self._test(~(a1.user is not None), "addresses_1.user_id IS NULL")
 
     def test_relationship_unimplemented(self):
         User = self.classes.User
@@ -1212,7 +1212,7 @@ class OperatorTest(QueryTest, AssertsCompiledSQL):
 
         # needs autoaliasing
         self._test(
-            Node.children == None,
+            Node.children is None,
             "NOT (EXISTS (SELECT 1 FROM nodes AS nodes_1 "
             "WHERE nodes.id = nodes_1.parent_id))",
             entity=Node,
@@ -1220,25 +1220,25 @@ class OperatorTest(QueryTest, AssertsCompiledSQL):
         )
 
         self._test(
-            Node.parent == None,
+            Node.parent is None,
             "nodes.parent_id IS NULL",
             checkparams={}
         )
 
         self._test(
-            nalias.parent == None,
+            nalias.parent is None,
             "nodes_1.parent_id IS NULL",
             checkparams={}
         )
 
         self._test(
-            nalias.parent != None,
+            nalias.parent is not None,
             "nodes_1.parent_id IS NOT NULL",
             checkparams={}
         )
 
         self._test(
-            nalias.children == None,
+            nalias.children is None,
             "NOT (EXISTS ("
             "SELECT 1 FROM nodes WHERE nodes_1.id = nodes.parent_id))",
             entity=nalias,
@@ -2180,7 +2180,7 @@ class FilterTest(QueryTest, AssertsCompiledSQL):
             assert True
 
         assert [User(id=10)] == \
-            sess.query(User).filter(User.addresses == None).all()
+            sess.query(User).filter(User.addresses is None).all()
 
         try:
             assert [User(id=7), User(id=9), User(id=10)] == \
@@ -2343,11 +2343,11 @@ class FilterTest(QueryTest, AssertsCompiledSQL):
             sess.query(Address).filter(Address.user != user).all()
 
         # generates an IS NULL
-        assert [] == sess.query(Address).filter(Address.user == None).all()
+        assert [] == sess.query(Address).filter(Address.user is None).all()
         assert [] == sess.query(Address).filter(Address.user == null()).all()
 
         assert [Order(id=5)] == \
-            sess.query(Order).filter(Order.address == None).all()
+            sess.query(Order).filter(Order.address is None).all()
 
         # o2o
         dingaling = sess.query(Dingaling).get(2)
@@ -2356,10 +2356,10 @@ class FilterTest(QueryTest, AssertsCompiledSQL):
 
         # m2m
         eq_(
-            sess.query(Item).filter(Item.keywords == None).
+            sess.query(Item).filter(Item.keywords is None).
             order_by(Item.id).all(), [Item(id=4), Item(id=5)])
         eq_(
-            sess.query(Item).filter(Item.keywords != None).
+            sess.query(Item).filter(Item.keywords is not None).
             order_by(Item.id).all(), [Item(id=1), Item(id=2), Item(id=3)])
 
     def test_filter_by(self):
@@ -2414,7 +2414,7 @@ class FilterTest(QueryTest, AssertsCompiledSQL):
         # scalar
         eq_(
             [Order(description="order 5")],
-            sess.query(Order).filter(Order.address_id == None).all()
+            sess.query(Order).filter(Order.address_id is None).all()
         )
         eq_(
             [Order(description="order 5")],
@@ -2424,7 +2424,7 @@ class FilterTest(QueryTest, AssertsCompiledSQL):
         # o2o
         eq_(
             [Address(id=1), Address(id=3), Address(id=4)],
-            sess.query(Address).filter(Address.dingaling == None).
+            sess.query(Address).filter(Address.dingaling is None).
             order_by(Address.id).all())
         eq_(
             [Address(id=1), Address(id=3), Address(id=4)],
@@ -2432,7 +2432,7 @@ class FilterTest(QueryTest, AssertsCompiledSQL):
             order_by(Address.id).all())
         eq_(
             [Address(id=2), Address(id=5)],
-            sess.query(Address).filter(Address.dingaling != None).
+            sess.query(Address).filter(Address.dingaling is not None).
             order_by(Address.id).all())
         eq_(
             [Address(id=2), Address(id=5)],
@@ -2442,19 +2442,19 @@ class FilterTest(QueryTest, AssertsCompiledSQL):
         # m2o
         eq_(
             [Order(id=5)],
-            sess.query(Order).filter(Order.address == None).all())
+            sess.query(Order).filter(Order.address is None).all())
         eq_(
             [Order(id=1), Order(id=2), Order(id=3), Order(id=4)],
             sess.query(Order).order_by(Order.id).
-            filter(Order.address != None).all())
+            filter(Order.address is not None).all())
 
         # o2m
         eq_(
             [User(id=10)],
-            sess.query(User).filter(User.addresses == None).all())
+            sess.query(User).filter(User.addresses is None).all())
         eq_(
             [User(id=7), User(id=8), User(id=9)],
-            sess.query(User).filter(User.addresses != None).
+            sess.query(User).filter(User.addresses is not None).
             order_by(User.id).all())
 
     def test_blank_filter_by(self):

--- a/test/orm/test_unitofwork.py
+++ b/test/orm/test_unitofwork.py
@@ -467,7 +467,7 @@ class ClauseAttributesTest(fixtures.MappedTest):
         assert_raises_message(
             TypeError,
             "Boolean value of this clause is not defined",
-            bool, None == sa.false()
+            bool, None is sa.false()
         )
         s = create_session()
         hb = HasBoolean(value=None)

--- a/test/sql/test_compiler.py
+++ b/test/sql/test_compiler.py
@@ -3773,7 +3773,7 @@ class CoercionTest(fixtures.TestBase, AssertsCompiledSQL):
 
     def test_val_is_null_coerced(self):
         t = self._fixture()
-        self.assert_compile(and_(t.c.id == None),
+        self.assert_compile(and_(t.c.id is None),
                             "foo.id IS NULL")
 
     def test_val_and_None(self):

--- a/test/sql/test_functions.py
+++ b/test/sql/test_functions.py
@@ -384,7 +384,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_funcfilter_criterion(self):
         self.assert_compile(
             func.count(1).filter(
-                table1.c.name != None
+                table1.c.name is not None
             ),
             "count(:count_1) FILTER (WHERE mytable.name IS NOT NULL)"
         )
@@ -392,7 +392,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_funcfilter_compound_criterion(self):
         self.assert_compile(
             func.count(1).filter(
-                table1.c.name == None,
+                table1.c.name is None,
                 table1.c.myid > 0
             ),
             "count(:count_1) FILTER (WHERE mytable.name IS NULL AND "
@@ -402,7 +402,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
     def test_funcfilter_label(self):
         self.assert_compile(
             select([func.count(1).filter(
-                table1.c.description != None
+                table1.c.description is not None
             ).label('foo')]),
             "SELECT count(:count_1) FILTER (WHERE mytable.description "
             "IS NOT NULL) AS foo FROM mytable"
@@ -414,7 +414,7 @@ class CompileTest(fixtures.TestBase, AssertsCompiledSQL):
         self.assert_compile(
             select([
                 func.max(table1.c.name).filter(
-                    literal_column('description') != None
+                    literal_column('description') is not None
                 )
             ]),
             "SELECT max(mytable.name) FILTER (WHERE description "

--- a/test/sql/test_operators.py
+++ b/test/sql/test_operators.py
@@ -1281,7 +1281,7 @@ class OperatorPrecedenceTest(fixtures.TestBase, testing.AssertsCompiledSQL):
 
     def test_operator_precedence_1(self):
         self.assert_compile(
-            self.table2.select((self.table2.c.field == 5) == None),
+            self.table2.select((self.table2.c.field == 5) is None),
             "SELECT op.field FROM op WHERE (op.field = :field_1) IS NULL")
 
     def test_operator_precedence_2(self):

--- a/test/sql/test_query.py
+++ b/test/sql/test_query.py
@@ -488,7 +488,7 @@ class QueryTest(fixtures.TestBase):
         s = users.select(users.c.user_name.in_([]) == False)  # noqa
         r = s.execute().fetchall()
         assert len(r) == 2
-        s = users.select(users.c.user_name.in_([]) == None)  # noqa
+        s = users.select(users.c.user_name.in_([]) is None)  # noqa
         r = s.execute().fetchall()
         assert len(r) == 1
 

--- a/test/sql/test_types.py
+++ b/test/sql/test_types.py
@@ -762,7 +762,7 @@ class TypeCoerceCastTest(fixtures.TablesTest):
 
         eq_(
             select([t.c.data, coerce_fn(t.c.data, MyType)]).
-            where(coerce_fn(t.c.data, MyType) == None).  # noqa
+            where(coerce_fn(t.c.data, MyType) is None).  # noqa
             execute().fetchall(),
             []
         )
@@ -1936,7 +1936,7 @@ class ExpressionTest(
         c3 = column('x', CoerceNone())
 
         self.assert_compile(
-            and_(c1 == None, c2 == None, c3 == None),  # noqa
+            and_(c1 is None, c2 is None, c3 is None),  # noqa
             "x = :x_1 AND x = :x_2 AND x IS NULL"
         )
         self.assert_compile(


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:vmuriart:sqlalchemy?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
